### PR TITLE
add env variables for rust toolchain

### DIFF
--- a/.github/workflows/ci_suite.yml
+++ b/.github/workflows/ci_suite.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches:
     - master
+env:
+  toolchain: stable
+  target: i686-unknown-linux-gnu
 jobs:
   run_linters:
     if: "!contains(github.event.head_commit.message, '[ci skip]')"


### PR DESCRIPTION
Adds environment variables for rust toolchain action so it properly sets up the environment, wherever those were before, they won't ever change anyway.