### PR TITLE
Changes Jet's recipe to milk instead of soy milk.

### DIFF
--- a/code/datums/components/crafting/recipes/recipes_medicine.dm
+++ b/code/datums/components/crafting/recipes/recipes_medicine.dm
@@ -119,8 +119,8 @@
 /datum/crafting_recipe/jet
 	name = "Jet"
 	result = /obj/item/reagent_containers/pill/patch/jet
-	reqs = list(/obj/item/clothing/mask/cigarette = 2,
-				/datum/reagent/consumable/milk = 15,
+	reqs = list(/obj/item/clothing/mask/cigarette = 1,
+				/datum/reagent/consumable/milk = 10,
 				/obj/item/toy/crayon/spraycan = 1)
 	time = 35
 	tools = list(TOOL_WORKBENCH)

--- a/code/datums/components/crafting/recipes/recipes_medicine.dm
+++ b/code/datums/components/crafting/recipes/recipes_medicine.dm
@@ -120,7 +120,7 @@
 	name = "Jet"
 	result = /obj/item/reagent_containers/pill/patch/jet
 	reqs = list(/obj/item/clothing/mask/cigarette = 2,
-				/datum/reagent/consumable/soymilk = 15,
+				/datum/reagent/consumable/milk = 15,
 				/obj/item/toy/crayon/spraycan = 1)
 	time = 35
 	tools = list(TOOL_WORKBENCH)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Title, also makes it slightly easier to craft.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Infinite Jet? No, because cigarettes aren't infinite, but you can make a lot now. Soy milk isn't obtainable normally, so.
Brahmin milk > !!SOY!! milk BTW.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: jet crafting recipe is now normal milk
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
