### PR TITLE
Oasis revitalization plan 1

### DIFF
--- a/code/modules/jobs/job_types/oasis.dm
+++ b/code/modules/jobs/job_types/oasis.dm
@@ -667,6 +667,8 @@ Mayor
 		/datum/outfit/loadout/properlady,
 		/datum/outfit/loadout/propergent,
 		/datum/outfit/loadout/hombre,
+		/datum/outfit/loadout/secretary,
+		/datum/outfit/loadout/singer,
 	)
 	access = list(ACCESS_BAR)
 	minimal_access = list(ACCESS_BAR)

--- a/code/modules/jobs/job_types/oasis.dm
+++ b/code/modules/jobs/job_types/oasis.dm
@@ -212,22 +212,20 @@ Mayor
 		/obj/item/ammo_box/shotgun/bean = 1,
 		/obj/item/ammo_box/shotgun/buck = 1,
 		/obj/item/ammo_box/c38 = 3,
-		/obj/item/melee/classic_baton = 1,
+		/obj/item/flashlight/seclite = 1,
 		)
 		
 /datum/outfit/loadout/pmc
 	name = "Private Contractor"
 	uniform = /obj/item/clothing/under/f13/combat/militia
 	suit = /obj/item/clothing/suit/armor/vest/alt
-	head = /obj/item/clothing/head/soft/f13/utility/olive
+	head = /obj/item/clothing/head/helmet
 	r_hand = /obj/item/gun/ballistic/automatic/smg/smg10mm/worn
 	belt = /obj/item/melee/onehanded/knife/switchblade
 	shoes = /obj/item/clothing/shoes/jackboots
 	backpack_contents = list(
-		/obj/item/clothing/head/helmet = 1,
 		/obj/item/ammo_box/magazine/m10mm_adv/ext = 1,
 		)
-	
 	
 /datum/outfit/job/den/f13deputy/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	..()

--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -258,7 +258,7 @@
 /obj/item/gun/ballistic/automatic/smg/smg10mm/worn
 	name = "worn-out 10mm submachine gun"
 	desc = "Mass-produced weapon from the Great War, this one has seen use ever since. Grip is wrapped in tape to keep the plastic from crumbling, the metals are oxidizing, but the gun still works."
-	init_mag_type = /obj/item/ammo_box/magazine/m10mm_adv/simple
+	init_mag_type = /obj/item/ammo_box/magazine/m10mm_adv/ext
 	worn_out = TRUE
 
 /obj/item/gun/ballistic/automatic/smg/smg10mm/burst_select()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

the two new loadouts have been accepted and will now be operational
PMC loadout has their bugged hat removed, worn 10mm starts with a 24 round mag
police loadout has the baton replaced with a seclite, to attach to their shotgun and to commit hate crimes
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

secretary and singer loadouts were approved, adds more variety to dress up game
hat was bugged, self explanatory
seclite allows you to make use of the shotguns light mount

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: hat removed
tweak: loadouts added to start list
balance: baton is now seclite
del: a bugged hat
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
