### PR TITLE
update byond to 513.1542

### DIFF
--- a/dependencies.sh
+++ b/dependencies.sh
@@ -5,7 +5,7 @@
 
 # byond version
 export BYOND_MAJOR=513
-export BYOND_MINOR=1536
+export BYOND_MINOR=1542
 
 #rust_g git tag
 export RUST_G_VERSION=0.4.7


### PR DESCRIPTION
Updates the BYOND version from `513.1536` to `513.1542` (latest, stable) for the CI workflow, should be self-explanatory.