### PR TITLE
Add chemical recipes for the various chems

### DIFF
--- a/code/modules/reagents/chemistry/recipes/medicine.dm
+++ b/code/modules/reagents/chemistry/recipes/medicine.dm
@@ -369,13 +369,12 @@ datum/chemical_reaction/rezadone
 	for(var/i = 1, i <= created_volume, i++)
 		new /obj/item/stack/medical/mesh/(location)
 
-/*/datum/chemical_reaction/stimpak
+/datum/chemical_reaction/stimpak
 	name = "Stimpak Fluid"
 	id = /datum/reagent/medicine/stimpak
 	results = list(/datum/reagent/medicine/stimpak = 1)
 	required_reagents = list(/datum/reagent/blood = 1, /datum/reagent/medicine/spaceacillin = 1)
 	required_temp = 300
-*/
 
 /datum/chemical_reaction/mentats
 	name = "mentats"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR enables the chemistry route for making stimfluid again, removing the dependency on broc and xander for those with access to chemistry equipment and the knowledge (IC and OOC) to use it. 

Edit: This PR has been expanded to apply to the rest of the chems and give them recipes too. Read the first comment for more information.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
It makes very little sense for this not to be able to be synthesized, and having it disabled some time ago is perceived as a nerf against the Followers in particular. It takes a considerable amount of time for the dedicated healing faction to be able to able to create stims to use or sell. Crafting them is still quicker and easier if you have a decent grow operation going. The truly big brained could automate stim production using chemistry.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: 0xEFF
tweak: Enable stimfluid chemistry again
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
