### PR TITLE
Makes simplemob thieves less cancerous

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/f13/raider.dm
+++ b/code/modules/mob/living/simple_animal/hostile/f13/raider.dm
@@ -37,20 +37,23 @@
 /mob/living/simple_animal/hostile/raider/thief/AttackingTarget()
 	if(ishuman(target))
 		var/mob/living/carbon/human/H = target
-		var/back_target = H.back
-		if(back_target)
-			H.dropItemToGround(back_target, TRUE)
-			src.transferItemToLoc(back_target, src, TRUE)
-		var/belt_target = H.belt
-		if(belt_target)
-			H.dropItemToGround(belt_target, TRUE)
-			src.transferItemToLoc(belt_target, src, TRUE)
-		var/shoe_target = H.shoes
-		if(shoe_target)
-			H.dropItemToGround(shoe_target, TRUE)
-			src.transferItemToLoc(shoe_target, src, TRUE)
-	retreat_distance = 50
-	addtimer(CALLBACK(src, .proc/undo_retreat), 5 MINUTES)
+		if(H.stat == SOFT_CRIT)
+			var/back_target = H.back
+			if(back_target)
+				H.dropItemToGround(back_target, TRUE)
+				src.transferItemToLoc(back_target, src, TRUE)
+			var/belt_target = H.belt
+			if(belt_target)
+				H.dropItemToGround(belt_target, TRUE)
+				src.transferItemToLoc(belt_target, src, TRUE)
+			var/shoe_target = H.shoes
+			if(shoe_target)
+				H.dropItemToGround(shoe_target, TRUE)
+				src.transferItemToLoc(shoe_target, src, TRUE)
+			retreat_distance = 50
+			addtimer(CALLBACK(src, .proc/undo_retreat), 5 MINUTES)
+		else
+			. = ..()
 
 /mob/living/simple_animal/hostile/raider/thief/proc/undo_retreat()
 	retreat_distance = null


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
The thieves as they are now will just run up to you and instantly steal your shit without any real chance of stopping them without killing them before they get to you. This is incredibly annoying, the thief shouldn't be able to just walk up and steal your shit. So, I've added a check for whether or not the target is in soft crit for this stealing behavior, and they'll attack otherwise.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Having your things stolen without any indication, timer, or condition is not fun.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: 0xEFF
balance: Thief simplemobs now have to softcrit you before stealing
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
