### PR TITLE
Wardrobe additions

### DIFF
--- a/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
@@ -986,12 +986,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/white/whitesolid,
 /area/f13/building)
-"atV" = (
-/obj/machinery/vending/clothing,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/building)
 "auc" = (
 /obj/structure/ladder/unbreakable{
 	height = 2;
@@ -6615,7 +6609,7 @@
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "cYu" = (
-/obj/machinery/vending/wardrobe,
+/obj/machinery/vending/clothing,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
@@ -11244,13 +11238,7 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/village)
 "eZO" = (
-/obj/structure/rack,
-/obj/item/clothing/head/fedora,
-/obj/item/clothing/head/frenchberet,
-/obj/item/clothing/head/flatcap,
-/obj/item/clothing/under/shorts/black,
-/obj/item/clothing/under/shorts/red,
-/obj/item/clothing/under/shorts/blue,
+/obj/machinery/vending/autodrobe,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
@@ -96594,7 +96582,7 @@ gts
 gts
 gts
 gts
-atV
+vYv
 dMc
 xFS
 vYv

--- a/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
@@ -22472,6 +22472,13 @@
 "qcp" = (
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/bunker)
+"qcN" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/vending/clothing,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/brotherhood/operations)
 "qdj" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/airlock/grunge{
@@ -25842,13 +25849,6 @@
 	icon_state = "housewood2"
 	},
 /area/f13/tunnel)
-"sKj" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/vending/wardrobe,
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/brotherhood/operations)
 "sLx" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
@@ -74059,7 +74059,7 @@ xBs
 yhh
 aGH
 aGH
-sKj
+qcN
 cxR
 cSH
 dwv


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Added at the request of frok/ghoulius, places a couple of wardrobe machines around the map. 
One wardrobe vendor in the BoS armory, for covert operations.
Red wardrobe vendor in the clothes shop that has wacky outfits for character gimmicks, or also for sneaking around.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Let people have fun with funny outfits, or more easily get an outfit that doesn't mark them as part of a specific faction.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: 0xEFF
tweak: Adds wardrobe vendors to the BoS bunker and the nearby clothes shop
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
