### PR TITLE
Stops book waste

### DIFF
--- a/code/game/objects/items/granters.dm
+++ b/code/game/objects/items/granters.dm
@@ -817,7 +817,7 @@
 	if(HAS_TRAIT(user, TRAIT_SURGERY_MID) || HAS_TRAIT(user, TRAIT_SURGERY_HIGH))
 		to_chat(user, "<span class ='notice'>This book is too basic for you!")
 		return TRUE
-	return FALSE
+	return ..()
 
 /obj/item/book/granter/trait/midsurgery
 	name = "D.C. Journal of Internal Medicine"
@@ -827,11 +827,11 @@
 	traitname = "intermediate surgery"
 	remarks = list("Sterilization is essential before and after surgery.", "Keep track of all your tools, double check body cavities.", "Ensure complete focus while operating on the patient.", "Cauterize incisions once the operation concludes.", "Spare organs and blood must be kept at a low temperature.", "Most prosthesis come with significant trade-offs, and maintenance costs.",)
 
-/obj/item/book/granter/trait/lowsurgery/already_known(mob/user)
+/obj/item/book/granter/trait/midsurgery/already_known(mob/user)
 	if(HAS_TRAIT(user, TRAIT_SURGERY_HIGH))
 		to_chat(user, "<span class ='notice'>This book is too basic for you!")
 		return TRUE
-	return FALSE
+	return ..()
 
 /obj/item/book/granter/trait/techno
 	name = "Dean's Electronics"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Stops people with high surgery skill form being able to read (and waste) a lower tier book.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Stops people with high surgery skill form being able to read (and waste) a lower tier book.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: You can no longer read basic books if you exceed it's skill level.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
