### PR TITLE
Hotfix for some compilation errors caused by Oasis jobs and a gun.

### DIFF
--- a/code/modules/jobs/job_types/oasis.dm
+++ b/code/modules/jobs/job_types/oasis.dm
@@ -113,22 +113,22 @@ Mayor
 	ears = 			/obj/item/radio/headset/headset_town
 	uniform =  		/obj/item/clothing/under/f13/sheriff
 	neck =			/obj/item/storage/belt/holster
-	shoes = 		/obj/item/clothing/shoes/f13/cowboy	
+	shoes = 		/obj/item/clothing/shoes/f13/cowboy
 	glasses =		/obj/item/clothing/glasses/sunglasses
 	l_pocket =		/obj/item/storage/bag/money/small/den
 	backpack_contents = list(
-		/obj/item/storage/box/deputy_badges = 1
+		/obj/item/storage/box/deputy_badges = 1,
 		/obj/item/restraints/handcuffs = 1,
 		/obj/item/melee/classic_baton = 1,
 		/obj/item/melee/onehanded/knife/hunting = 1,
 		)
-		
+
 /datum/outfit/loadout/thelaw
 	name = "Law Man"
 	suit = /obj/item/clothing/suit/armor/f13/town/sheriff
 	head = /obj/item/clothing/head/f13/town/sheriff
 	r_hand = /obj/item/gun/ballistic/rifle/repeater/brush
-	belt = /obj/item/gun/ballistic/revolver/m29/peacekeeper = 1
+	belt = /obj/item/gun/ballistic/revolver/m29/peacekeeper
 	backpack_contents = list(
 		/obj/item/ammo_box/tube/c4570 = 3,
 		/obj/item/ammo_box/m44 = 2,

--- a/code/modules/projectiles/guns/ballistic/pistol.dm
+++ b/code/modules/projectiles/guns/ballistic/pistol.dm
@@ -127,7 +127,7 @@
 	name = "Sig P220"
 	desc = "The P220 Sig Sauer. A Swiss designed pistol that is compact and has a good rate of fire."
 	icon_state = "sig"
-	w_class = WEIGHT_CLASS_SMALL 
+	w_class = WEIGHT_CLASS_SMALL
 	mag_type = /obj/item/ammo_box/magazine/m9mm
 	fire_delay = 3
 	can_attachments = TRUE
@@ -135,11 +135,11 @@
 	suppressor_x_offset = 30
 	suppressor_y_offset = 20
 	fire_sound = 'sound/f13weapons/9mm.ogg'
-	
+
 //side grade to the peacemaker 		    Keywords: OASIS, 9mm, Semi-auto, +5 damage, 10 round magazine, 0 spread, faster rate of fire, bullet speed +100, probably needs a new sprite
 /obj/item/gun/ballistic/automatic/pistol/sig/commissioner
 	name = "The Defender"
-	desc = "A modified Sig P225 salvaged from the boneyard. Boasts a faster rate of fire and laser-like accuracy. It has "To Protect and Serve" etched on the side."
+	desc = "A modified Sig P225 salvaged from the boneyard. Boasts a faster rate of fire and laser-like accuracy. It has 'To Protect and Serve' etched on the side."
 	w_class = WEIGHT_CLASS_SMALL
 	extra_damage = 5
 	fire_delay = 2.6
@@ -267,7 +267,7 @@
 	icon_state = "deagle"
 	item_state = "deagle"
 	mag_type = /obj/item/ammo_box/magazine/m44
-	weapon_weight = WEAPON_MEDIUM 
+	weapon_weight = WEAPON_MEDIUM
 	force = 15
 	extra_damage = 3
 	extra_speed = 300
@@ -293,7 +293,7 @@
 	icon_state = "automag"
 	item_state = "deagle"
 	mag_type = /obj/item/ammo_box/magazine/automag
-	weapon_weight = WEAPON_MEDIUM 
+	weapon_weight = WEAPON_MEDIUM
 	extra_damage = 2
 	extra_speed = 300
 	fire_delay = 3.7


### PR DESCRIPTION
Description of a gun had internal quotations, changed to apostrophes. Oasis job file had a missing comma and an unnecessary "=1", caused compilation errors. Fixed.