### PR TITLE
Nullrod Nerf

### DIFF
--- a/code/game/objects/items/holy_weapons.dm
+++ b/code/game/objects/items/holy_weapons.dm
@@ -292,9 +292,9 @@
 	user.visible_message("<span class='suicide'>[user] is killing [user.p_them()]self with [src]! It looks like [user.p_theyre()] trying to get closer to god!</span>")
 	return (BRUTELOSS|FIRELOSS)
 
-/obj/item/nullrod/attack_self(mob/user)
-	/*if(user.mind && (user.mind.isholy) && !reskinned)
-		reskin_holy_weapon(user)*/ 
+/*/obj/item/nullrod/attack_self(mob/user)
+	if(user.mind && (user.mind.isholy) && !reskinned)
+		reskin_holy_weapon(user)*/
 
 /**
  * reskin_holy_weapon: Shows a user a list of all available nullrod reskins and based on his choice replaces the nullrod with the reskinned version

--- a/code/game/objects/items/holy_weapons.dm
+++ b/code/game/objects/items/holy_weapons.dm
@@ -269,7 +269,7 @@
 
 /obj/item/nullrod
 	name = "null rod"
-	desc = "A rod of pure obsidian; its very presence disrupts and dampens the powers of Nar'Sie and Ratvar's followers."
+	desc = "A rod of pure obsidian; its very presence disrupts and dampens the powers of evil spirits."
 	icon_state = "nullrod"
 	item_state = "nullrod"
 	lefthand_file = 'icons/mob/inhands/weapons/melee_lefthand.dmi'
@@ -293,8 +293,8 @@
 	return (BRUTELOSS|FIRELOSS)
 
 /obj/item/nullrod/attack_self(mob/user)
-	if(user.mind && (user.mind.isholy) && !reskinned)
-		reskin_holy_weapon(user)
+	/*if(user.mind && (user.mind.isholy) && !reskinned)
+		reskin_holy_weapon(user)*/ 
 
 /**
  * reskin_holy_weapon: Shows a user a list of all available nullrod reskins and based on his choice replaces the nullrod with the reskinned version


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Nerfs the nullrod so it can't be reskinned anymore. Also removes a Nar Nar reference.

## Why It's Good For The Game

Nerfs the nullrod so it can't be reskinned anymore. Also removes a Nar Nar reference.

## Changelog
:cl:
del: The nullrod can no longer be reskinned.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
