### PR TITLE
Fixes daturatea fruit

### DIFF
--- a/code/modules/fallout/reagents/alcohol.dm
+++ b/code/modules/fallout/reagents/alcohol.dm
@@ -159,7 +159,7 @@
 	..()
 
 /datum/reagent/consumable/ethanol/daturatea/on_mob_delete(mob/living/M)
-	ADD_TRAIT(M, TRAIT_SPIRITUAL, "[type]")
+	REMOVE_TRAIT(M, TRAIT_SPIRITUAL, "[type]")
 	M.set_drugginess(0)
 	M.hallucination += 0
 	..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes daturatea fruit so it correctly removes the spiritual trait after it leaves the body.

## Why It's Good For The Game

Prevents players from getting a free trait.

## Pre-Merge Checklist
- [X] Your Pull Request contains no breaking changes
- [ ] You tested your changes locally, and they work.
- [X] There are no new Runtimes that appear.
- [X] You documented all of your changes.

<!-- Please check these accordingly. -->

## Changelog
:cl:
fix: Fixes daturatea fruit from letting you get a free spiritual trait.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
