### PR TITLE
Quick bunker map tweaks, and fixes a ladder.

### DIFF
--- a/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
@@ -38124,6 +38124,15 @@
 /obj/structure/barricade/wooden/planks/pregame,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/building)
+"rzI" = (
+/obj/structure/ladder/unbreakable{
+	height = 2;
+	id = "oasis3"
+	},
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain1"
+	},
+/area/f13/wasteland)
 "rzR" = (
 /obj/machinery/light{
 	dir = 8
@@ -84173,7 +84182,7 @@ sgz
 erY
 dma
 erY
-hOl
+rzI
 hOl
 sgz
 sgz

--- a/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
@@ -1210,9 +1210,14 @@
 /turf/closed/wall/f13/supermart,
 /area/f13/building)
 "ayE" = (
-/obj/item/storage/money_stack,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/building)
+/obj/structure/ladder/unbreakable{
+	height = 2;
+	id = "oasis3"
+	},
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain1"
+	},
+/area/f13/wasteland)
 "ayU" = (
 /obj/structure/chair/f13chair2{
 	dir = 4
@@ -38124,15 +38129,6 @@
 /obj/structure/barricade/wooden/planks/pregame,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/building)
-"rzI" = (
-/obj/structure/ladder/unbreakable{
-	height = 2;
-	id = "oasis3"
-	},
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "verticalinnermain1"
-	},
-/area/f13/wasteland)
 "rzR" = (
 /obj/machinery/light{
 	dir = 8
@@ -84182,7 +84178,7 @@ sgz
 erY
 dma
 erY
-rzI
+ayE
 hOl
 sgz
 sgz
@@ -89157,7 +89153,7 @@ dCV
 jix
 hzm
 hzm
-ayE
+hzm
 dCV
 gcK
 gcK

--- a/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
@@ -328,9 +328,6 @@
 	},
 /area/f13/brotherhood/operations)
 "amC" = (
-/obj/structure/curtain{
-	color = "#5c131b"
-	},
 /turf/open/floor/wood,
 /area/f13/brotherhood/operations)
 "amD" = (
@@ -16092,6 +16089,12 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/bunker)
+"jXs" = (
+/obj/structure/curtain{
+	color = "#5c131b"
+	},
+/turf/open/floor/wood/f13/stage_t,
+/area/f13/brotherhood/operations)
 "jXu" = (
 /obj/structure/lattice{
 	density = 1
@@ -98116,7 +98119,7 @@ wKL
 wKL
 wKL
 nqO
-nqO
+jXs
 nqO
 axv
 nqO
@@ -100698,19 +100701,19 @@ eLE
 eLE
 eLE
 eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
+qvn
+qvn
+qvn
+qvn
+qvn
+qvn
+qvn
+qvn
+qvn
+qvn
+qvn
+qvn
+qvn
 eLE
 eLE
 eLE

--- a/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
@@ -2514,9 +2514,8 @@
 /turf/open/water,
 /area/f13/tunnel)
 "bDz" = (
-/obj/structure/simple_door/bunker{
+/obj/machinery/door/airlock/grunge{
 	name = "Head Knight's Office";
-	req_access = 120;
 	req_access_txt = "120"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -3312,7 +3311,8 @@
 /turf/open/floor/wood,
 /area/f13/brotherhood/leisure)
 "cam" = (
-/obj/structure/simple_door/blast{
+/obj/machinery/door/airlock/hatch{
+	desc = "An airtight door, built to withstand a nuclear blast.";
 	max_integrity = 10000;
 	name = "bunker entry";
 	req_access_txt = "120"
@@ -14240,13 +14240,14 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/den)
 "itI" = (
-/obj/structure/simple_door/blast{
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/hatch{
+	desc = "An airtight door, built to withstand a nuclear blast.";
 	max_integrity = 10000;
 	name = "bunker entry";
 	req_access_txt = "120"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
 	},
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
@@ -15791,23 +15792,10 @@
 	},
 /area/f13/bunker)
 "jKo" = (
-/obj/structure/flora/rock/jungle{
-	density = 1
+/obj/machinery/autolathe,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
 	},
-/obj/structure/flora/grass/jungle/b,
-/obj/structure/flora/ausbushes/grassybush{
-	layer = 2.1
-	},
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 1;
-	layer = 3
-	},
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 8
-	},
-/turf/open/water,
 /area/f13/brotherhood/leisure)
 "jKW" = (
 /obj/effect/decal/cleanable/insectguts,
@@ -16089,12 +16077,6 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/bunker)
-"jXs" = (
-/obj/structure/curtain{
-	color = "#5c131b"
-	},
-/turf/open/floor/wood/f13/stage_t,
-/area/f13/brotherhood/operations)
 "jXu" = (
 /obj/structure/lattice{
 	density = 1
@@ -18700,6 +18682,12 @@
 /obj/structure/wreck/trash/four_barrels,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/tunnel)
+"mgi" = (
+/obj/structure/curtain{
+	color = "#5c131b"
+	},
+/turf/open/floor/wood/f13/stage_t,
+/area/f13/brotherhood/operations)
 "mhc" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin,
@@ -19444,7 +19432,9 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "mKh" = (
-/obj/structure/simple_door/bunker,
+/obj/machinery/door/airlock/grunge{
+	req_access_txt = "120"
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/medical)
 "mKn" = (
@@ -19774,6 +19764,12 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/bunker)
+"mTf" = (
+/obj/machinery/workbench,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
+/area/f13/brotherhood/leisure)
 "mTj" = (
 /obj/effect/turf_decal/caution/stand_clear,
 /obj/effect/decal/cleanable/dirt,
@@ -21312,13 +21308,12 @@
 /turf/closed/wall/f13/wood,
 /area/f13/tunnel)
 "nRq" = (
-/obj/structure/simple_door/bunker{
-	name = "Head Paladin's Office";
-	req_access = 120;
-	req_access_txt = "120"
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/grunge{
+	name = "Head Paladin's Office";
+	req_access_txt = "120"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/offices1st)
@@ -22396,11 +22391,13 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/operations)
 "oDY" = (
-/obj/structure/simple_door/blast{
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock/hatch{
+	desc = "An airtight door, built to withstand a nuclear blast.";
 	max_integrity = 10000;
+	name = "bunker entry";
 	req_access_txt = "120"
 	},
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/operations)
 "oDZ" = (
@@ -24093,9 +24090,8 @@
 /area/f13/brotherhood/offices1st)
 "pME" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/simple_door/bunker{
-	name = "Senior Knight Office";
-	req_access = 120;
+/obj/machinery/door/airlock/grunge{
+	name = "Senior Knight's Office";
 	req_access_txt = "120"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -24878,12 +24874,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
 "qmV" = (
-/obj/structure/simple_door/bunker{
-	name = "Paladin Halls";
-	req_access = 120;
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock/grunge{
 	req_access_txt = "120"
 	},
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/offices1st)
 "qmZ" = (
@@ -90690,7 +90684,7 @@ hpM
 gKP
 gKP
 gKP
-jJM
+mTf
 iAR
 iAR
 iAR
@@ -98119,7 +98113,7 @@ wKL
 wKL
 wKL
 nqO
-jXs
+mgi
 nqO
 axv
 nqO


### PR DESCRIPTION
## About The Pull Request

This moves an offset curtain in the bunker, and handles an area where some dense rock was showing against the bunker walls. This also fixes a ladder that was destroyed by the oasis reworks in the sewers, to now have an exit just south of Oasis by the highway. Also replaces the simple_door blastdoors in the bunker entrance and some areas of the bunker so that they actually work with access requirements. Adds a workbench and autolathe to hydro.

## Why It's Good For The Game

Fixes broken stuff. People can no longer sprint through the BoS doors without access. Loss of workbench and autolathe in hydro was an oversight, makes actual stim production way easier.

## Pre-Merge Checklist
- [X ] Your Pull Request contains no breaking changes
- [X ] You tested your changes locally, and they work.
- [X ] There are no new Runtimes that appear.
- [X ] You documented all of your changes.

<!-- Please check these accordingly. -->

## Changelog
:cl:
fix: Fixes broken ladder, fixes dense rock showing, fixes offset curtain.
add: Workbench and autolathe in hydro
tweak: Replaces some doors with proper airlocks so that access works.
del: Removes payroll safe from surface area.
/:cl:

