### PR TITLE
Removes the capes from the BoS paladins, replaces with shoulder holsters.

### DIFF
--- a/code/modules/jobs/job_types/bos.dm
+++ b/code/modules/jobs/job_types/bos.dm
@@ -145,7 +145,7 @@ Head Paladin
 	head = 			/obj/item/clothing/head/helmet/f13/power_armor/t60
 	mask =			/obj/item/clothing/mask/gas/sechailer/swat
 	id = 			/obj/item/card/id/dogtag
-	neck = 			/obj/item/clothing/neck/mantle/bos/paladin
+	neck = 			/obj/item/storage/belt/holster
 	backpack_contents = list(
 		/obj/item/melee/onehanded/knife/hunting = 1,
 		/obj/item/gun/ballistic/automatic/pistol/n99 = 1,
@@ -392,7 +392,7 @@ Star Paladin
 	uniform =	/obj/item/clothing/under/f13/recon
 	mask =	/obj/item/clothing/mask/gas/sechailer/swat
 	belt =	/obj/item/storage/belt/military/assault
-	neck =	/obj/item/clothing/neck/mantle/bos/paladin
+	neck =	/obj/item/storage/belt/holster
 
 	backpack_contents = list(
 		/obj/item/gun/energy/laser/plasma/pistol = 1,
@@ -484,7 +484,7 @@ Paladin
 	uniform =	/obj/item/clothing/under/f13/recon
 	mask =	/obj/item/clothing/mask/gas/sechailer/swat
 	belt =	/obj/item/storage/belt/military
-	neck =	/obj/item/clothing/neck/mantle/bos/paladin
+	neck =	/obj/item/storage/belt/holster
 	backpack_contents = list(
 		/obj/item/melee/onehanded/knife/hunting = 1,
 		/obj/item/reagent_containers/hypospray/medipen/stimpak/super = 1,


### PR DESCRIPTION
## About The Pull Request

Something we've wanted to do in the BoS loreteam for a while. Capes are a holdover from DR where the chapter tried to be more Midwestern, doesn't match up with our lore.

## Why It's Good For The Game

Capes lame. Fits with lore better.

## Pre-Merge Checklist
- [X] Your Pull Request contains no breaking changes
- [X] You tested your changes locally, and they work.
- [X] There are no new Runtimes that appear.
- [X] You documented all of your changes.

<!-- Please check these accordingly. -->

## Changelog
:cl:
tweak: Changes BoS paladins to spawn with shoulder holsters instead of capes.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
