### PR TITLE
Removes closet looking for ghosts

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -116,6 +116,9 @@
 		var/mob/living/L = user
 		if(HAS_TRAIT(L, TRAIT_SKITTISH))
 			. += "<span class='notice'>Ctrl-Shift-click [src] to jump inside.</span>"
+	if(isobserver(user) && check_rights_for(user.client, R_ADMIN))
+		. += "<span class='info'>It contains: [english_list(contents)].</span>"
+		investigate_log("had its contents examined by [user] as a ghost.", INVESTIGATE_GHOST)
 
 /obj/structure/closet/CanPass(atom/movable/mover, border_dir)
 	if(wall_mounted)

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -116,9 +116,6 @@
 		var/mob/living/L = user
 		if(HAS_TRAIT(L, TRAIT_SKITTISH))
 			. += "<span class='notice'>Ctrl-Shift-click [src] to jump inside.</span>"
-	if(isobserver(user))
-		. += "<span class='info'>It contains: [english_list(contents)].</span>"
-		investigate_log("had its contents examined by [user] as a ghost.", INVESTIGATE_GHOST)
 
 /obj/structure/closet/CanPass(atom/movable/mover, border_dir)
 	if(wall_mounted)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Disallows ghosts from viewing what's in closets unless they are an admin.

## Why It's Good For The Game

This helps combat meta.

## Pre-Merge Checklist
- [X] Your Pull Request contains no breaking changes
- [X] You tested your changes locally, and they work.
- [X] There are no new Runtimes that appear.
- [X] You documented all of your changes.

<!-- Please check these accordingly. -->

## Changelog
:cl:
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
