### PR TITLE
Quirk fixes + Removal of Bluespace Plant Mutation

### DIFF
--- a/code/datums/good.dm
+++ b/code/datums/good.dm
@@ -1,0 +1,347 @@
+//predominantly positive traits
+//this file is named weirdly so that positive traits are listed above negative ones
+
+/datum/quirk/alcohol_tolerance
+	name = "Alcohol Tolerance"
+	desc = "You become drunk more slowly and suffer fewer drawbacks from alcohol."
+	value = 1
+	mob_trait = TRAIT_ALCOHOL_TOLERANCE
+	gain_text = "<span class='notice'>You feel like you could drink a whole keg!</span>"
+	lose_text = "<span class='danger'>You don't feel as resistant to alcohol anymore. Somehow.</span>"
+	medical_record_text = "Patient demonstrates a high tolerance for alcohol."
+
+
+/datum/quirk/tribal
+	name = "Former Tribal"
+	desc = "You used to be part of one of the tribes scattered throughout the wasteland. You may have some additional skills as a result, though advanced tech still confuses you."
+	value = 2
+	gain_text = "<span class='notice'>You remember the old ways of your tribe..</span>"
+	lose_text = "<span class='notice'>You've forgotten the ways of your ancestors..</span>"
+
+/datum/quirk/tribal/add()
+	var/mob/living/carbon/human/H = quirk_holder
+	ADD_TRAIT(H, TRAIT_TECHNOPHOBE, "Former Tribal")
+	ADD_TRAIT(H, TRAIT_TRIBAL, "Former Tribal")
+
+/datum/quirk/tribal/remove()
+	var/mob/living/carbon/human/H = quirk_holder
+	REMOVE_TRAIT(H, TRAIT_TECHNOPHOBE, "Former Tribal")
+	REMOVE_TRAIT(H, TRAIT_TRIBAL, "Former Tribal")
+
+
+/datum/quirk/apathetic
+	name = "Apathetic"
+	desc = "You just don't care as much as other people. That's nice to have in a place like this, I guess."
+	value = 1
+	mood_quirk = TRUE
+	medical_record_text = "Patient was administered the Apathy Evaluation Scale but did not bother to complete it."
+
+/datum/quirk/apathetic/add()
+	var/datum/component/mood/mood = quirk_holder.GetComponent(/datum/component/mood)
+	if(mood)
+		mood.mood_modifier = 0.8
+
+/datum/quirk/apathetic/remove()
+	if(quirk_holder)
+		var/datum/component/mood/mood = quirk_holder.GetComponent(/datum/component/mood)
+		if(mood)
+			mood.mood_modifier = 1 //Change this once/if species get their own mood modifiers.
+
+/datum/quirk/drunkhealing
+	name = "Drunken Resilience"
+	desc = "Nothing like a good drink to make you feel on top of the world. Whenever you're drunk, you slowly recover from injuries."
+	value = 2
+	mob_trait = TRAIT_DRUNK_HEALING
+	gain_text = "<span class='notice'>You feel like a drink would do you good.</span>"
+	lose_text = "<span class='danger'>You no longer feel like drinking would ease your pain.</span>"
+	medical_record_text = "Patient has unusually efficient liver metabolism and can slowly regenerate wounds by drinking alcoholic beverages."
+
+/datum/quirk/empath
+	name = "Empath"
+	desc = "Whether it's a sixth sense or careful study of body language, it only takes you a quick glance at someone to understand how they feel."
+	value = 2
+	mob_trait = TRAIT_EMPATH
+	gain_text = "<span class='notice'>You feel in tune with those around you.</span>"
+	lose_text = "<span class='danger'>You feel isolated from others.</span>"
+	medical_record_text = "Patient is highly perceptive of and sensitive to social cues, or may possibly have ESP. Further testing needed."
+
+/datum/quirk/freerunning
+	name = "Freerunning"
+	desc = "You're great at quick moves! You can climb tables more quickly."
+	value = 2
+	mob_trait = TRAIT_FREERUNNING
+	gain_text = "<span class='notice'>You feel lithe on your feet!</span>"
+	lose_text = "<span class='danger'>You feel clumsy again.</span>"
+	medical_record_text = "Patient scored highly on cardio tests."
+
+/datum/quirk/friendly
+	name = "Friendly"
+	desc = "You give the best hugs, especially when you're in the right mood."
+	value = 1
+	mob_trait = TRAIT_FRIENDLY
+	gain_text = "<span class='notice'>You want to hug someone.</span>"
+	lose_text = "<span class='danger'>You no longer feel compelled to hug others.</span>"
+	mood_quirk = TRUE
+	medical_record_text = "Patient demonstrates low-inhibitions for physical contact and well-developed arms. Requesting another doctor take over this case."
+
+/datum/quirk/jolly
+	name = "Jolly"
+	desc = "You sometimes just feel happy, for no reason at all."
+	value = 1
+	mob_trait = TRAIT_JOLLY
+	mood_quirk = TRUE
+	medical_record_text = "Patient demonstrates constant euthymia irregular for environment. It's a bit much, to be honest."
+
+/datum/quirk/jolly/on_process()
+	if(prob(0.05))
+		SEND_SIGNAL(quirk_holder, COMSIG_ADD_MOOD_EVENT, "jolly", /datum/mood_event/jolly)
+
+/datum/quirk/light_step
+	name = "Light Step"
+	desc = "You walk with a gentle step; stepping on sharp objects is quieter, less painful and you won't leave footprints behind you."
+	value = 1
+	mob_trait = TRAIT_LIGHT_STEP
+	gain_text = "<span class='notice'>You walk with a little more litheness.</span>"
+	lose_text = "<span class='danger'>You start tromping around like a barbarian.</span>"
+	medical_record_text = "Patient's dexterity belies a strong capacity for stealth."
+
+/*
+/datum/quirk/quick_step
+	name = "Quick Step"
+	desc = "You walk with determined strides, and out-pace most people when walking."
+	value = 2
+	mob_trait = TRAIT_SPEEDY_STEP
+	gain_text = "<span class='notice'>You feel determined. No time to lose.</span>"
+	lose_text = "<span class='danger'>You feel less determined. What's the rush, man?</span>"
+	medical_record_text = "Patient scored highly on racewalking tests."
+*/
+
+/datum/quirk/musician
+	name = "Musician"
+	desc = "You can tune handheld musical instruments to play melodies that clear certain negative effects and soothe the soul."
+	value = 1
+	mob_trait = TRAIT_MUSICIAN
+	gain_text = "<span class='notice'>You know everything about musical instruments.</span>"
+	lose_text = "<span class='danger'>You forget how musical instruments work.</span>"
+	medical_record_text = "Patient brain scans show a highly-developed auditory pathway."
+
+/datum/quirk/musician/on_spawn()
+	var/mob/living/carbon/human/H = quirk_holder
+	var/obj/item/choice_beacon/music/B = new(get_turf(H))
+	H.put_in_hands(B)
+	H.equip_to_slot_if_possible(B, SLOT_IN_BACKPACK)
+	var/obj/item/musicaltuner/musicaltuner = new(get_turf(H))
+	H.put_in_hands(musicaltuner)
+	H.equip_to_slot_if_possible(musicaltuner, SLOT_IN_BACKPACK)
+	H.regenerate_icons()
+
+/datum/quirk/photographer
+	name = "Photographer"
+	desc = "You know how to handle a camera, shortening the delay between each shot."
+	value = 1
+	mob_trait = TRAIT_PHOTOGRAPHER
+	gain_text = "<span class='notice'>You know everything about photography.</span>"
+	lose_text = "<span class='danger'>You forget how photo cameras work.</span>"
+	medical_record_text = "Patient mentions photography as a stress-relieving hobby."
+
+/datum/quirk/photographer/on_spawn()
+	var/mob/living/carbon/human/H = quirk_holder
+	var/obj/item/camera/camera = new(get_turf(H))
+	H.put_in_hands(camera)
+	H.equip_to_slot(camera, SLOT_NECK)
+	H.regenerate_icons()
+
+/datum/quirk/selfaware
+	name = "Self-Aware"
+	desc = "You know your body well, and can accurately assess the extent of your wounds."
+	value = 2
+	mob_trait = TRAIT_SELF_AWARE
+	medical_record_text = "Patient demonstrates an uncanny knack for self-diagnosis."
+
+/datum/quirk/skittish
+	name = "Skittish"
+	desc = "You can conceal yourself in danger. Ctrl-shift-click a closed locker to jump into it, as long as you have access."
+	value = 2
+	mob_trait = TRAIT_SKITTISH
+	medical_record_text = "Patient demonstrates a high aversion to danger and has described hiding in containers out of fear."
+
+/datum/quirk/spiritual
+	name = "Spiritual"
+	desc = "You're in tune with the gods, and your prayers may be more likely to be heard. Or not."
+	value = 1
+	mob_trait = TRAIT_SPIRITUAL
+	gain_text = "<span class='notice'>You feel a little more faithful to the gods today.</span>"
+	lose_text = "<span class='danger'>You feel less faithful in the gods.</span>"
+	medical_record_text = "Patient reports a belief in a higher power."
+
+/datum/quirk/tagger
+	name = "Tagger"
+	desc = "You're an experienced artist. While drawing graffiti, you can get twice as many uses out of drawing supplies."
+	value = 1
+	mob_trait = TRAIT_TAGGER
+	gain_text = "<span class='notice'>You know how to tag walls efficiently.</span>"
+	lose_text = "<span class='danger'>You forget how to tag walls properly.</span>"
+	medical_record_text = "Patient was recently seen for possible paint huffing incident."
+
+/datum/quirk/tagger/on_spawn()
+	var/mob/living/carbon/human/H = quirk_holder
+	var/obj/item/toy/crayon/spraycan/spraycan = new(get_turf(H))
+	H.put_in_hands(spraycan)
+	H.equip_to_slot(spraycan, SLOT_IN_BACKPACK)
+	H.regenerate_icons()
+
+/datum/quirk/voracious
+	name = "Voracious"
+	desc = "Nothing gets between you and your food. You eat twice as fast as everyone else!"
+	value = 1
+	mob_trait = TRAIT_VORACIOUS
+	gain_text = "<span class='notice'>You feel HONGRY.</span>"
+	lose_text = "<span class='danger'>You no longer feel HONGRY.</span>"
+	medical_record_text = "Patient demonstrates a disturbing capacity for eating."
+
+/datum/quirk/bloodpressure
+	name = "Polycythemia vera"
+	desc = "You've a treated form of Polycythemia vera that increases the total blood volume inside of you as well as the rate of replenishment!"
+	value = 2 //I honeslty dunno if this is a good trait? I just means you use more of medbays blood and make janitors madder, but you also regen blood a lil faster.
+	mob_trait = TRAIT_HIGH_BLOOD
+	gain_text = "<span class='notice'>You feel full of blood!</span>"
+	lose_text = "<span class='notice'>You feel like your blood pressure went down.</span>"
+	medical_record_text = "Patient's blood tests report an abnormal concentration of red blood cells in their bloodstream."
+
+/datum/quirk/bloodpressure/add()
+	quirk_holder.blood_ratio = 1.2
+	quirk_holder.blood_volume += 150
+
+/datum/quirk/bloodpressure/remove()
+	if(quirk_holder)
+		quirk_holder.blood_ratio = 1
+
+/datum/quirk/machine_spirits
+	name = "Spirit Blessed"
+	desc = "You respect the teachings of the Machine Spirits."
+	value = 3
+	mob_trait = TRAIT_MACHINE_SPIRITS
+	gain_text = "<span class='notice'>You have recieved the blessing of the Machine Spirits.</span>"
+	lose_text = "<span class='danger'>You've lost the  blessing of the Machine Spirits.</span>"
+	locked = TRUE
+
+/datum/quirk/night_vision
+	name = "Night Vision"
+	desc = "You can see slightly more clearly in full darkness than most people."
+	value = 1
+	mob_trait = TRAIT_NIGHT_VISION
+	gain_text = "<span class='notice'>The shadows seem a little less dark.</span>"
+	lose_text = "<span class='danger'>Everything seems a little darker.</span>"
+	locked = TRUE
+
+/datum/quirk/night_vision/on_spawn()
+	var/mob/living/carbon/human/H = quirk_holder
+	H.update_sight()
+
+/datum/quirk/trapper
+	name = "Trapper"
+	desc = "As an experienced hunter and trapper you know your way around butchering animals for their products, and are able to get twice the usable materials by eliminating waste."
+	value = 2
+	mob_trait = TRAIT_TRAPPER
+	gain_text = "<span class='notice'>You learn the secrets of butchering!</span>"
+	lose_text = "<span class='danger'>You forget how to slaughter animals.</span>"
+	locked = TRUE
+
+/datum/quirk/bigleagues
+	name = "Big Leagues"
+	desc = "Swing for the fences! You deal additional damage with melee weapons."
+	value = 2
+	mob_trait = TRAIT_BIG_LEAGUES
+	gain_text = "<span class='notice'>You feel like swinging for the fences!</span>"
+	lose_text = "<span class='danger'>You feel like bunting.</span>"
+	locked = TRUE
+
+/datum/quirk/chemwhiz
+	name = "Chem Whiz"
+	desc = "You've been playing around with chemicals all your life. You know how to use chemistry machinery."
+	value = 2
+	mob_trait = TRAIT_CHEMWHIZ
+	gain_text = "<span class='notice'>The mysteries of chemistry are revealed to you.</span>"
+	lose_text = "<span class='danger'>You forget how the periodic table works.</span>"
+	locked = TRUE
+
+/datum/quirk/pa_wear
+	name = "PA Wear"
+	desc = "You've being around the wastes and have learned the importance of defense."
+	value = 3
+	mob_trait = TRAIT_PA_WEAR
+	gain_text = "<span class='notice'>You realize how to use Power Armor.</span>"
+	lose_text = "<span class='danger'>You forget how Power Armor works.</span>"
+	locked = TRUE
+
+/datum/quirk/hard_yards
+	name = "Hard Yards"
+	desc = "You've put them in, now reap the rewards."
+	value = 3
+	mob_trait = TRAIT_HARD_YARDS
+	gain_text = "<span class='notice'>Rain or shine, nothing slows you down.</span>"
+	lose_text = "<span class='danger'>You walk with a less sure gait, the ground seeming less firm somehow.</span>"
+	locked = TRUE
+
+/datum/quirk/lifegiver
+	name = "Lifegiver"
+	desc = "You embody wellness! Instantly gain +10 maximum Health"
+	value = 3
+	mob_trait = TRAIT_LIFEGIVER
+	gain_text = "<span class='notice'>You feel more healthy than usual.</span>"
+	lose_text = "<span class='danger'>You feel less healthy than usual.</span>"
+	locked = TRUE
+
+/datum/quirk/lifegiver/on_spawn()
+	var/mob/living/carbon/human/mob_tar = quirk_holder
+	mob_tar.maxHealth += 10
+	mob_tar.health += 10
+
+/datum/quirk/iron_fist
+	name = "Iron Fist"
+	desc = "You have fists of kung-fury! Increases unarmed damage."
+	value = 2
+	mob_trait = TRAIT_IRONFIST
+	gain_text = "<span class='notice'>Your fists feel furious!</span>"
+	lose_text = "<span class='danger'>Your fists feel calm again.</span>"
+	locked = TRUE
+
+/datum/quirk/iron_fist/on_spawn()
+	var/mob/living/carbon/human/mob_tar = quirk_holder
+	mob_tar.dna.species.punchdamagelow = 4
+	mob_tar.dna.species.punchdamagehigh = 11
+
+/datum/quirk/light_step
+	name = "Light Step"
+	desc = "You walk with a gentle step, making stepping on sharp objects quieter and less painful."
+	value = 1
+	mob_trait = TRAIT_LIGHT_STEP
+	gain_text = "<span class='notice'>You walk with a little more litheness.</span>"
+	lose_text = "<span class='danger'>You start tromping around like a barbarian.</span>"
+
+/datum/quirk/surgerylow
+	name = "Minor Surgery"
+	desc = "You are a somewhat adequate medical practicioner, capable of performing minor surgery."
+	value = 1
+	mob_trait = TRAIT_SURGERY_LOW
+	gain_text = "<span class='notice'>You feel yourself discovering the basics of the human body.</span>"
+	lose_text = "<span class='danger'>You forget how to perform even the simplest surgery.</span>"
+	locked = TRUE
+
+/datum/quirk/surgerymid
+	name = "Intermediate Surgery"
+	desc = "You are a skilled medical practicioner, capable of performing most surgery."
+	value = 1
+	mob_trait = TRAIT_SURGERY_MID
+	gain_text = "<span class='notice'>You feel yourself discovering most of the details of the human body.</span>"
+	lose_text = "<span class='danger'>You forget how to perform surgery.</span>"
+	locked = TRUE
+
+/datum/quirk/surgeryhigh
+	name = "Complex Surgery"
+	desc = "You are an expert practicioner, capable of performing almost all surgery."
+	value = 1
+	mob_trait = TRAIT_SURGERY_HIGH
+	gain_text = "<span class='notice'>You feel yourself discovering the most intricate secrets of the human body.</span>"
+	lose_text = "<span class='danger'>You forget your advanced surgical knowledge.</span>"
+	locked = TRUE

--- a/code/datums/negative.dm
+++ b/code/datums/negative.dm
@@ -1,0 +1,422 @@
+//predominantly negative traits
+
+/datum/quirk/blooddeficiency
+	name = "Acute Blood Deficiency"
+	desc = "Your body can't produce enough blood to sustain itself."
+	value = -2
+	gain_text = "<span class='danger'>You feel your vigor slowly fading away.</span>"
+	lose_text = "<span class='notice'>You feel vigorous again.</span>"
+	antag_removal_text = "Your antagonistic nature has removed your blood deficiency."
+	medical_record_text = "Patient requires regular treatment for blood loss due to low production of blood."
+
+/datum/quirk/blooddeficiency/on_process()
+	var/mob/living/carbon/human/H = quirk_holder
+	if(NOBLOOD in H.dna.species.species_traits) //can't lose blood if your species doesn't have any
+		return
+	else
+		quirk_holder.blood_volume -= 0.2
+
+/datum/quirk/depression
+	name = "Depression"
+	desc = "You sometimes just hate life."
+	mob_trait = TRAIT_DEPRESSION
+	value = -1
+	gain_text = "<span class='danger'>You start feeling depressed.</span>"
+	lose_text = "<span class='notice'>You no longer feel depressed.</span>" //if only it were that easy!
+	medical_record_text = "Patient has a severe mood disorder, causing them to experience acute episodes of depression."
+	mood_quirk = TRUE
+
+/datum/quirk/depression/on_process()
+	if(prob(0.05))
+		SEND_SIGNAL(quirk_holder, COMSIG_ADD_MOOD_EVENT, "depression", /datum/mood_event/depression)
+
+/datum/quirk/family_heirloom
+	name = "Family Heirloom"
+	desc = "You are the current owner of an heirloom, passed down for generations. You have to keep it safe!"
+	value = -1
+	mood_quirk = TRUE
+	medical_record_text = "Patient demonstrates an unnatural attachment to a family heirloom."
+	var/obj/item/heirloom
+	var/where
+
+GLOBAL_LIST_EMPTY(family_heirlooms)
+
+/datum/quirk/family_heirloom/on_spawn()
+	var/mob/living/carbon/human/H = quirk_holder
+	var/obj/item/heirloom_type
+	switch(quirk_holder.mind.assigned_role)
+		if("Cook")
+			heirloom_type = /obj/item/kitchen/knife/butcher
+		if("Botanist")
+			heirloom_type = pick(/obj/item/cultivator, /obj/item/reagent_containers/glass/bucket, /obj/item/storage/bag/plants, /obj/item/toy/plush/beeplushie)
+		if("Medical Doctor")
+			heirloom_type = /obj/item/healthanalyzer
+		if("Paramedic")
+			heirloom_type = /obj/item/lighter
+		if("Station Engineer")
+			heirloom_type = /obj/item/wirecutters/brass
+		if("Atmospheric Technician")
+			heirloom_type = /obj/item/extinguisher/mini/family
+		if("Lawyer")
+			heirloom_type = /obj/item/storage/briefcase/lawyer/family
+		if("Janitor")
+			heirloom_type = /obj/item/mop
+		if("Security Officer")
+			heirloom_type = /obj/item/clothing/accessory/medal/silver/valor
+		if("Scientist")
+			heirloom_type = /obj/item/toy/plush/slimeplushie
+		if("Assistant")
+			heirloom_type = /obj/item/clothing/gloves/cut/family
+		if("Chaplain")
+			heirloom_type = /obj/item/camera/spooky/family
+		if("Captain")
+			heirloom_type = /obj/item/clothing/accessory/medal/gold/captain/family
+	if(!heirloom_type)
+		heirloom_type = pick(
+		/obj/item/toy/cards/deck,
+		/obj/item/lighter,
+		/obj/item/dice/d20)
+	heirloom = new heirloom_type(get_turf(quirk_holder))
+	GLOB.family_heirlooms += heirloom
+	var/list/slots = list(
+		"in your left pocket" = SLOT_L_STORE,
+		"in your right pocket" = SLOT_R_STORE,
+		"in your backpack" = SLOT_IN_BACKPACK
+	)
+	where = H.equip_in_one_of_slots(heirloom, slots, FALSE) || "at your feet"
+
+/datum/quirk/family_heirloom/post_add()
+	if(where == "in your backpack")
+		var/mob/living/carbon/human/H = quirk_holder
+		SEND_SIGNAL(H.back, COMSIG_TRY_STORAGE_SHOW, H)
+
+	to_chat(quirk_holder, "<span class='boldnotice'>There is a precious family [heirloom.name] [where], passed down from generation to generation. Keep it safe!</span>")
+	var/list/family_name = splittext(quirk_holder.real_name, " ")
+	heirloom.name = "\improper [family_name[family_name.len]] family [heirloom.name]"
+
+/datum/quirk/family_heirloom/on_process()
+	if(heirloom in quirk_holder.GetAllContents())
+		SEND_SIGNAL(quirk_holder, COMSIG_CLEAR_MOOD_EVENT, "family_heirloom_missing")
+		SEND_SIGNAL(quirk_holder, COMSIG_ADD_MOOD_EVENT, "family_heirloom", /datum/mood_event/family_heirloom)
+	else
+		SEND_SIGNAL(quirk_holder, COMSIG_CLEAR_MOOD_EVENT, "family_heirloom")
+		SEND_SIGNAL(quirk_holder, COMSIG_ADD_MOOD_EVENT, "family_heirloom_missing", /datum/mood_event/family_heirloom_missing)
+
+/datum/quirk/family_heirloom/clone_data()
+	return heirloom
+
+/datum/quirk/family_heirloom/on_clone(data)
+	heirloom = data
+
+/datum/quirk/heavy_sleeper
+	name = "Heavy Sleeper"
+	desc = "You sleep like a rock! Whenever you're put to sleep, you sleep for a little bit longer."
+	value = -1
+	mob_trait = TRAIT_HEAVY_SLEEPER
+	gain_text = "<span class='danger'>You feel sleepy.</span>"
+	lose_text = "<span class='notice'>You feel awake again.</span>"
+	medical_record_text = "Patient has abnormal sleep study results and is difficult to wake up."
+
+/datum/quirk/brainproblems
+	name = "Brain Tumor"
+	desc = "You have a little friend in your brain that is slowly destroying it. Better bring some mannitol!"
+	value = -3
+	gain_text = "<span class='danger'>You feel smooth.</span>"
+	lose_text = "<span class='notice'>You feel wrinkled again.</span>"
+	medical_record_text = "Patient has a tumor in their brain that is slowly driving them to brain death."
+
+/datum/quirk/brainproblems/on_process()
+	quirk_holder.adjustOrganLoss(ORGAN_SLOT_BRAIN, 0.2)
+
+/datum/quirk/nearsighted //t. errorage
+	name = "Nearsighted"
+	desc = "You are nearsighted without prescription glasses, but spawn with a pair."
+	value = -1
+	gain_text = "<span class='danger'>Things far away from you start looking blurry.</span>"
+	lose_text = "<span class='notice'>You start seeing faraway things normally again.</span>"
+	medical_record_text = "Patient requires prescription glasses in order to counteract nearsightedness."
+
+/datum/quirk/nearsighted/add()
+	quirk_holder.become_nearsighted(ROUNDSTART_TRAIT)
+
+/datum/quirk/nearsighted/on_spawn()
+	var/mob/living/carbon/human/H = quirk_holder
+	var/obj/item/clothing/glasses/regular/glasses = new(get_turf(H))
+	if(!H.equip_to_slot_if_possible(glasses, SLOT_GLASSES))
+		H.put_in_hands(glasses)
+
+/datum/quirk/nyctophobia
+	name = "Nyctophobia"
+	desc = "As far as you can remember, you've always been afraid of the dark. While in the dark without a light source, you instinctually act careful, and constantly feel a sense of dread."
+	value = -1
+	medical_record_text = "Patient demonstrates a fear of the dark."
+
+/datum/quirk/nyctophobia/on_process()
+	var/mob/living/carbon/human/H = quirk_holder
+	if(H.dna.species.id in list("shadow", "nightmare"))
+		return //we're tied with the dark, so we don't get scared of it; don't cleanse outright to avoid cheese
+	var/turf/T = get_turf(quirk_holder)
+	var/lums = T.get_lumcount()
+	if(lums <= 0.2)
+		if(quirk_holder.m_intent == MOVE_INTENT_RUN)
+			to_chat(quirk_holder, "<span class='warning'>Easy, easy, take it slow... you're in the dark...</span>")
+			quirk_holder.toggle_move_intent()
+		SEND_SIGNAL(quirk_holder, COMSIG_ADD_MOOD_EVENT, "nyctophobia", /datum/mood_event/nyctophobia)
+	else
+		SEND_SIGNAL(quirk_holder, COMSIG_CLEAR_MOOD_EVENT, "nyctophobia")
+
+/datum/quirk/lightless
+	name = "Light Sensitivity"
+	desc = "Bright lights irritate you. Your eyes start to water, your skin feels itchy against the photon radiation, and your hair gets dry and frizzy. Maybe it's a medical condition."
+	value = -1
+	gain_text = "<span class='danger'>The safety of light feels off...</span>"
+	lose_text = "<span class='notice'>Enlightening.</span>"
+	medical_record_text = "Patient has acute phobia of light, and insists it is physically harmful."
+
+/datum/quirk/lightless/on_process()
+	var/turf/T = get_turf(quirk_holder)
+	var/lums = T.get_lumcount()
+	if(lums >= 0.8)
+		SEND_SIGNAL(quirk_holder, COMSIG_ADD_MOOD_EVENT, "brightlight", /datum/mood_event/brightlight)
+	else
+		SEND_SIGNAL(quirk_holder, COMSIG_CLEAR_MOOD_EVENT, "brightlight")
+
+/datum/quirk/nonviolent
+	name = "Pacifist"
+	desc = "The thought of violence makes you sick. So much so, in fact, that you can't hurt anyone."
+	value = -2
+	mob_trait = TRAIT_PACIFISM
+	gain_text = "<span class='danger'>You feel repulsed by the thought of violence!</span>"
+	lose_text = "<span class='notice'>You think you can defend yourself again.</span>"
+	medical_record_text = "Patient is unusually pacifistic and cannot bring themselves to cause physical harm."
+	antag_removal_text = "Your antagonistic nature has caused you to renounce your pacifism."
+
+/datum/quirk/paraplegic
+	name = "Paraplegic"
+	desc = "Your legs do not function. Nothing will ever fix this. Luckily you found a wheelchair."
+	value = -3
+	mob_trait = TRAIT_PARA
+	human_only = TRUE
+	gain_text = null // Handled by trauma.
+	lose_text = null
+	medical_record_text = "Patient has an untreatable impairment in motor function in the lower extremities."
+
+/datum/quirk/paraplegic/add()
+	var/datum/brain_trauma/severe/paralysis/paraplegic/T = new()
+	var/mob/living/carbon/human/H = quirk_holder
+	H.gain_trauma(T, TRAUMA_RESILIENCE_ABSOLUTE)
+
+/datum/quirk/paraplegic/on_spawn()
+	if(quirk_holder.client)
+		var/modified_limbs = quirk_holder.client.prefs.modified_limbs
+		if(!(modified_limbs[BODY_ZONE_L_LEG] == LOADOUT_LIMB_AMPUTATED && modified_limbs[BODY_ZONE_R_LEG] == LOADOUT_LIMB_AMPUTATED && !isjellyperson(quirk_holder)))
+			if(quirk_holder.buckled) // Handle late joins being buckled to arrival shuttle chairs.
+				quirk_holder.buckled.unbuckle_mob(quirk_holder)
+
+			var/turf/T = get_turf(quirk_holder)
+			var/obj/structure/chair/spawn_chair = locate() in T
+
+			var/obj/vehicle/ridden/wheelchair/wheels = new(T)
+			if(spawn_chair) // Makes spawning on the arrivals shuttle more consistent looking
+				wheels.setDir(spawn_chair.dir)
+
+			wheels.buckle_mob(quirk_holder)
+
+			// During the spawning process, they may have dropped what they were holding, due to the paralysis
+			// So put the things back in their hands.
+
+			for(var/obj/item/I in T)
+				if(I.fingerprintslast == quirk_holder.ckey)
+					quirk_holder.put_in_hands(I)
+
+/datum/quirk/poor_aim
+	name = "Poor Aim"
+	desc = "You're terrible with guns and can't line up a straight shot to save your life. Dual-wielding is right out."
+	value = -1
+	mob_trait = TRAIT_POOR_AIM
+	medical_record_text = "Patient possesses a strong tremor in both hands."
+
+/datum/quirk/prosopagnosia
+	name = "Prosopagnosia"
+	desc = "You have a mental disorder that prevents you from being able to recognize faces at all."
+	value = -1
+	mob_trait = TRAIT_PROSOPAGNOSIA
+	medical_record_text = "Patient suffers from prosopagnosia, and cannot recognize faces."
+
+/datum/quirk/insanity
+	name = "Reality Dissociation Syndrome"
+	desc = "You suffer from a severe disorder that causes very vivid hallucinations. Mindbreaker toxin can suppress its effects, and you are immune to mindbreaker's hallucinogenic properties. <b>This is not a license to grief.</b>"
+	value = -2
+	//no mob trait because it's handled uniquely
+	gain_text = "<span class='userdanger'>...</span>"
+	lose_text = "<span class='notice'>You feel in tune with the world again.</span>"
+	medical_record_text = "Patient suffers from acute Reality Dissociation Syndrome and experiences vivid hallucinations."
+
+/datum/quirk/insanity/on_process()
+	if(quirk_holder.reagents.has_reagent(/datum/reagent/toxin/mindbreaker))
+		quirk_holder.hallucination = 0
+		return
+	if(prob(2)) //we'll all be mad soon enough
+		madness()
+
+/datum/quirk/insanity/proc/madness()
+	quirk_holder.hallucination += rand(10, 25)
+
+/datum/quirk/insanity/post_add() //I don't /think/ we'll need this but for newbies who think "roleplay as insane" = "license to kill" it's probably a good thing to have
+	if(!quirk_holder.mind || quirk_holder.mind.special_role)
+		return
+	to_chat(quirk_holder, "<span class='big bold info'>Please note that your dissociation syndrome does NOT give you the right to attack people or otherwise cause any interference to \
+	the round. You are not an antagonist, and the rules will treat you the same as other crewmembers.</span>")
+
+/datum/quirk/social_anxiety
+	name = "Social Anxiety"
+	desc = "Talking to people is very difficult for you, and you often stutter or even lock up."
+	value = -1
+	gain_text = "<span class='danger'>You start worrying about what you're saying.</span>"
+	lose_text = "<span class='notice'>You feel easier about talking again.</span>" //if only it were that easy!
+	medical_record_text = "Patient is usually anxious in social encounters and prefers to avoid them."
+	var/dumb_thing = TRUE
+
+/datum/quirk/social_anxiety/add()
+	RegisterSignal(quirk_holder, COMSIG_MOB_EYECONTACT, .proc/eye_contact)
+	RegisterSignal(quirk_holder, COMSIG_MOB_EXAMINATE, .proc/looks_at_floor)
+
+/datum/quirk/social_anxiety/remove()
+	UnregisterSignal(quirk_holder, list(COMSIG_MOB_EYECONTACT, COMSIG_MOB_EXAMINATE))
+
+/datum/quirk/social_anxiety/on_process()
+	var/nearby_people = 0
+	for(var/mob/living/carbon/human/H in oview(3, quirk_holder))
+		if(H.client)
+			nearby_people++
+	var/mob/living/carbon/human/H = quirk_holder
+	if(prob(2 + nearby_people))
+		H.stuttering = max(3, H.stuttering)
+	else if(prob(min(3, nearby_people)) && !H.silent)
+		to_chat(H, "<span class='danger'>You retreat into yourself. You <i>really</i> don't feel up to talking.</span>")
+		H.silent = max(10, H.silent)
+	else if(prob(0.5) && dumb_thing)
+		to_chat(H, "<span class='userdanger'>You think of a dumb thing you said a long time ago and scream internally.</span>")
+		dumb_thing = FALSE //only once per life
+		if(prob(1))
+			new/obj/item/reagent_containers/food/snacks/pastatomato(get_turf(H)) //now that's what I call spaghetti code
+
+// small chance to make eye contact with inanimate objects/mindless mobs because of nerves
+/datum/quirk/social_anxiety/proc/looks_at_floor(datum/source, atom/A)
+	var/mob/living/mind_check = A
+	if(prob(85) || (istype(mind_check) && mind_check.mind))
+		return
+
+	addtimer(CALLBACK(GLOBAL_PROC, .proc/to_chat, quirk_holder, "<span class='smallnotice'>You make eye contact with [A].</span>"), 3)
+
+/datum/quirk/social_anxiety/proc/eye_contact(datum/source, mob/living/other_mob, triggering_examiner)
+	if(prob(75))
+		return
+	var/msg
+	if(triggering_examiner)
+		msg = "You make eye contact with [other_mob], "
+	else
+		msg = "[other_mob] makes eye contact with you, "
+
+	switch(rand(1,3))
+		if(1)
+			quirk_holder.Jitter(10)
+			msg += "causing you to start fidgeting!"
+		if(2)
+			quirk_holder.stuttering = max(3, quirk_holder.stuttering)
+			msg += "causing you to start stuttering!"
+		if(3)
+			quirk_holder.Stun(2 SECONDS)
+			msg += "causing you to freeze up!"
+
+	SEND_SIGNAL(quirk_holder, COMSIG_ADD_MOOD_EVENT, "anxiety_eyecontact", /datum/mood_event/anxiety_eyecontact)
+	addtimer(CALLBACK(GLOBAL_PROC, .proc/to_chat, quirk_holder, "<span class='userdanger'>[msg]</span>"), 3) // so the examine signal has time to fire and this will print after
+	return COMSIG_BLOCK_EYECONTACT
+
+/datum/mood_event/anxiety_eyecontact
+	description = "<span class='warning'>Sometimes eye contact makes me so nervous...</span>\n"
+	mood_change = -5
+	timeout = 3 MINUTES
+
+
+
+/datum/quirk/mute
+	name = "Mute"
+	desc = "Due to some accident, medical condition, or simply by choice, you are completely unable to speak."
+	value = -2 //HALP MAINTS
+	gain_text = "<span class='danger'>You find yourself unable to speak!</span>"
+	lose_text = "<span class='notice'>You feel a growing strength in your vocal chords.</span>"
+	medical_record_text = "Functionally mute, patient is unable to use their voice in any capacity."
+	antag_removal_text = "Your antagonistic nature has caused your voice to be heard."
+	var/datum/brain_trauma/severe/mute/mute
+
+/datum/quirk/mute/add()
+	var/mob/living/carbon/human/H = quirk_holder
+	mute = new
+	H.gain_trauma(mute, TRAUMA_RESILIENCE_ABSOLUTE)
+
+/datum/quirk/mute/remove()
+	var/mob/living/carbon/human/H = quirk_holder
+	H?.cure_trauma_type(mute, TRAUMA_RESILIENCE_ABSOLUTE)
+
+/datum/quirk/unstable
+	name = "Unstable"
+	desc = "Due to past troubles, you are unable to recover your sanity if you lose it. Be very careful managing your mood!"
+	value = -2
+	mob_trait = TRAIT_UNSTABLE
+	gain_text = "<span class='danger'>There's a lot on your mind right now.</span>"
+	lose_text = "<span class='notice'>Your mind finally feels calm.</span>"
+	medical_record_text = "Patient's mind is in a vulnerable state, and cannot recover from traumatic events."
+
+/datum/quirk/blindness
+	name = "Blind"
+	desc = "You are completely blind, nothing can counteract this."
+	value = -4
+	gain_text = "<span class='danger'>You can't see anything.</span>"
+	lose_text = "<span class='notice'>You miraculously gain back your vision.</span>"
+	medical_record_text = "Patient has permanent blindness."
+
+/datum/quirk/blindness/add()
+	quirk_holder.become_blind(ROUNDSTART_TRAIT)
+
+/datum/quirk/blindness/on_spawn()
+	var/mob/living/carbon/human/H = quirk_holder
+	var/obj/item/clothing/glasses/sunglasses/blindfold/white/glasses = new(get_turf(H))
+	if(!H.equip_to_slot_if_possible(glasses, SLOT_GLASSES, bypass_equip_delay_self = TRUE)) //if you can't put it on the user's eyes, put it in their hands, otherwise put it on their eyes eyes
+		H.put_in_hands(glasses)
+	H.regenerate_icons()
+
+/datum/quirk/blindness/remove()
+	quirk_holder?.cure_blind(ROUNDSTART_TRAIT)
+
+/datum/quirk/coldblooded
+	name = "Cold-blooded"
+	desc = "Your body doesn't create its own internal heat, requiring external heat regulation."
+	value = -2
+	medical_record_text = "Patient is ectothermic."
+	mob_trait = TRAIT_COLDBLOODED
+	gain_text = "<span class='notice'>You feel cold-blooded.</span>"
+	lose_text = "<span class='notice'>You feel more warm-blooded.</span>"
+
+/datum/quirk/monophobia
+	name = "Monophobia"
+	desc = "You will become increasingly stressed when not in company of others, triggering panic reactions ranging from sickness to heart attacks."
+	value = -3 // Might change it to 4.
+	gain_text = "<span class='danger'>You feel really lonely...</span>"
+	lose_text = "<span class='notice'>You feel like you could be safe on your own.</span>"
+	medical_record_text = "Patient feels sick and distressed when not around other people, leading to potentially lethal levels of stress."
+	/datum/quirk/monophobia/on_process()
+	if(prob(0.05))
+		SEND_SIGNAL(quirk_holder, COMSIG_ADD_MOOD_EVENT, "depression", /datum/mood_event/depression)
+
+	
+
+/datum/quirk/monophobia/post_add()
+	. = ..()
+	var/mob/living/carbon/human/H = quirk_holder
+	H.gain_trauma(/datum/brain_trauma/severe/monophobia, TRAUMA_RESILIENCE_ABSOLUTE)
+
+/datum/quirk/monophobia/remove()
+	. = ..()
+	var/mob/living/carbon/human/H = quirk_holder
+	H?.cure_trauma_type(/datum/brain_trauma/severe/monophobia, TRAUMA_RESILIENCE_ABSOLUTE)

--- a/code/datums/neutral.dm
+++ b/code/datums/neutral.dm
@@ -1,0 +1,162 @@
+//traits with no real impact that can be taken freely
+//MAKE SURE THESE DO NOT MAJORLY IMPACT GAMEPLAY. those should be positive or negative traits.
+
+/datum/quirk/no_taste
+	name = "Ageusia"
+	desc = "You can't taste anything! Toxic food will still poison you."
+	value = 0
+	mob_trait = TRAIT_AGEUSIA
+	gain_text = "<span class='notice'>You can't taste anything!</span>"
+	lose_text = "<span class='notice'>You can taste again!</span>"
+	medical_record_text = "Patient suffers from ageusia and is incapable of tasting food or reagents."
+
+	/datum/quirk/horrifying_tastes
+	name = "Horrifying Tastes"
+	desc = "You enjoy a fine sort of meal not often appreciated by your peers. To serve man, in all it's forms is your life's work. Put bluntly - you are a cannibal. Consuming human flesh doesn't bother you, and dishes such as longpork stew will heal you."
+	mob_trait = TRAIT_LONGPORKLOVER
+	value = 0
+	gain_text = "<span class='notice'>You have an insatiable hunger for the flesh of your fellow man.</span>"
+	lose_text = "<span class='notice'>The terrible hunger fades - you feel peace at last.</span>"
+	medical_record_text = "Patient refuses to comment on their dietary preferences."
+
+	/datum/quirk/horrifying_tastes/add()
+	var/mob/living/carbon/human/H = quirk_holder
+	var/datum/species/species = H.dna.species
+	species.liked_food |= LONGPORK
+	species.disliked_food &= ~LONGPORK
+
+/datum/quirk/horrifying_tastes/remove()
+	var/mob/living/carbon/human/H = quirk_holder
+	if(H)
+		var/datum/species/species = H.dna.species
+		species.liked_food &= ~LONGPORK
+		species.disliked_food |= LONGPORK
+
+/datum/quirk/snob
+	name = "Snob"
+	desc = "You care about the finer things, if a room doesn't look nice its just not really worth it, is it?"
+	value = 0
+	gain_text = "<span class='notice'>You feel like you understand what things should look like.</span>"
+	lose_text = "<span class='notice'>Well who cares about deco anyways?</span>"
+	medical_record_text = "Patient seems to be rather stuck up."
+	mob_trait = TRAIT_SNOB
+
+/datum/quirk/pineapple_liker
+	name = "Ananas Affinity"
+	desc = "You find yourself greatly enjoying fruits of the ananas genus. You can't seem to ever get enough of their sweet goodness!"
+	value = 0
+	gain_text = "<span class='notice'>You feel an intense craving for pineapple.</span>"
+	lose_text = "<span class='notice'>Your feelings towards pineapples seem to return to a lukewarm state.</span>"
+	medical_record_text = "Patient demonstrates a pathological love of pineapple."
+
+/datum/quirk/pineapple_liker/add()
+	var/mob/living/carbon/human/H = quirk_holder
+	var/datum/species/species = H.dna.species
+	species.liked_food |= PINEAPPLE
+
+/datum/quirk/pineapple_liker/remove()
+	var/mob/living/carbon/human/H = quirk_holder
+	if(H)
+		var/datum/species/species = H.dna.species
+		species.liked_food &= ~PINEAPPLE
+
+/datum/quirk/pineapple_hater
+	name = "Ananas Aversion"
+	desc = "You find yourself greatly detesting fruits of the ananas genus. Serious, how the hell can anyone say these things are good? And what kind of madman would even dare putting it on a pizza!?"
+	value = 0
+	gain_text = "<span class='notice'>You find yourself pondering what kind of idiot actually enjoys pineapples...</span>"
+	lose_text = "<span class='notice'>Your feelings towards pineapples seem to return to a lukewarm state.</span>"
+	medical_record_text = "Patient is correct to think that pineapple is disgusting."
+
+/datum/quirk/pineapple_hater/add()
+	var/mob/living/carbon/human/H = quirk_holder
+	var/datum/species/species = H.dna.species
+	species.disliked_food |= PINEAPPLE
+
+/datum/quirk/pineapple_hater/remove()
+	var/mob/living/carbon/human/H = quirk_holder
+	if(H)
+		var/datum/species/species = H.dna.species
+		species.disliked_food &= ~PINEAPPLE
+
+/datum/quirk/deviant_tastes
+	name = "Deviant Tastes"
+	desc = "You dislike food that most people enjoy, and find delicious what they don't."
+	value = 0
+	gain_text = "<span class='notice'>You start craving something that tastes strange.</span>"
+	lose_text = "<span class='notice'>You feel like eating normal food again.</span>"
+	medical_record_text = "Patient demonstrates irregular nutrition preferences."
+
+/datum/quirk/deviant_tastes/add()
+	var/mob/living/carbon/human/H = quirk_holder
+	var/datum/species/species = H.dna.species
+	var/liked = species.liked_food
+	species.liked_food = species.disliked_food
+	species.disliked_food = liked
+
+/datum/quirk/deviant_tastes/remove()
+	var/mob/living/carbon/human/H = quirk_holder
+	if(H)
+		var/datum/species/species = H.dna.species
+		species.liked_food = initial(species.liked_food)
+		species.disliked_food = initial(species.disliked_food)
+
+/datum/quirk/monochromatic
+	name = "Monochromacy"
+	desc = "You suffer from full colorblindness, and perceive nearly the entire world in blacks and whites."
+	value = 0
+	medical_record_text = "Patient is afflicted with almost complete color blindness."
+
+/datum/quirk/monochromatic/add()
+	quirk_holder.add_client_colour(/datum/client_colour/monochrome)
+
+/datum/quirk/monochromatic/post_add()
+	if(quirk_holder.mind.assigned_role == "Detective")
+		to_chat(quirk_holder, "<span class='boldannounce'>Mmm. Nothing's ever clear on this station. It's all shades of gray...</span>")
+		quirk_holder.playsound_local(quirk_holder, 'sound/ambience/ambidet1.ogg', 50, FALSE)
+
+/datum/quirk/monochromatic/remove()
+	if(quirk_holder)
+		quirk_holder.remove_client_colour(/datum/client_colour/monochrome)
+
+/datum/quirk/maso
+	name = "Masochism"
+	desc = "You are aroused by pain."
+	value = 0
+	mob_trait = TRAIT_MASO
+	gain_text = "<span class='notice'>You desire to be hurt.</span>"
+	lose_text = "<span class='notice'>Pain has become less exciting for you.</span>"
+
+/datum/quirk/alcohol_intolerance
+	name = "Alcohol Intolerance"
+	desc = "You take toxin damage from alcohol rather than getting drunk."
+	value = 0
+	mob_trait = TRAIT_NO_ALCOHOL
+	medical_record_text = "Patient's body does not react properly to ethyl alcohol."
+
+/datum/quirk/alcohol_intolerance/add()
+	var/mob/living/carbon/human/H = quirk_holder
+	var/datum/species/species = H.dna.species
+	species.disliked_food |= ALCOHOL
+
+/datum/quirk/alcohol_intolerance/remove()
+	var/mob/living/carbon/human/H = quirk_holder
+	if(H)
+		var/datum/species/species = H.dna.species
+		species.disliked_food &= ~ALCOHOL
+
+/datum/quirk/longtimer
+	name = "Longtimer"
+	desc = "You've been around for a long time and seen more than your fair share of action, suffering some pretty nasty scars along the way. For whatever reason, you've declined to get them removed or augmented."
+	value = 0
+	gain_text = "<span class='notice'>Your body has seen better days.</span>"
+	lose_text = "<span class='notice'>Your sins may wash away, but those scars are here to stay...</span>"
+	medical_record_text = "Patient has withstood significant physical trauma and declined plastic surgery procedures to heal scarring."
+	/// the minimum amount of scars we can generate
+	var/min_scars = 3
+	/// the maximum amount of scars we can generate
+	var/max_scars = 7
+
+/datum/quirk/longtimer/on_spawn()
+	var/mob/living/carbon/C = quirk_holder
+	C.generate_fake_scars(rand(min_scars, max_scars))

--- a/plant_genes.dm
+++ b/plant_genes.dm
@@ -1,0 +1,476 @@
+/datum/plant_gene
+	var/name
+	var/mutability_flags = PLANT_GENE_EXTRACTABLE | PLANT_GENE_REMOVABLE ///These flags tells the genemodder if we want the gene to be extractable, only removable or neither.
+
+/datum/plant_gene/proc/get_name() // Used for manipulator display and gene disk name.
+	var/formatted_name
+	if(!(mutability_flags & PLANT_GENE_REMOVABLE && mutability_flags & PLANT_GENE_EXTRACTABLE))
+		if(mutability_flags & PLANT_GENE_REMOVABLE)
+			formatted_name += "Fragile "
+		else if(mutability_flags & PLANT_GENE_EXTRACTABLE)
+			formatted_name += "Essential "
+		else
+			formatted_name += "Immutable "
+	formatted_name += name
+	return formatted_name
+
+/datum/plant_gene/proc/can_add(obj/item/seeds/S)
+	return !istype(S, /obj/item/seeds/sample) // Samples can't accept new genes
+
+/datum/plant_gene/proc/Copy()
+	var/datum/plant_gene/G = new type
+	G.mutability_flags = mutability_flags
+	return G
+
+/datum/plant_gene/proc/apply_vars(obj/item/seeds/S) // currently used for fire resist, can prob. be further refactored
+	return
+
+// Core plant genes store 5 main variables: lifespan, endurance, production, yield, potency
+/datum/plant_gene/core
+	var/value
+
+/datum/plant_gene/core/get_name()
+	return "[name] [value]"
+
+/datum/plant_gene/core/proc/apply_stat(obj/item/seeds/S)
+	return
+
+/datum/plant_gene/core/New(i = null)
+	..()
+	if(!isnull(i))
+		value = i
+
+/datum/plant_gene/core/Copy()
+	var/datum/plant_gene/core/C = ..()
+	C.value = value
+	return C
+
+/datum/plant_gene/core/can_add(obj/item/seeds/S)
+	if(!..())
+		return FALSE
+	return S.get_gene(src.type)
+
+/datum/plant_gene/core/lifespan
+	name = "Lifespan"
+	value = 25
+
+/datum/plant_gene/core/lifespan/apply_stat(obj/item/seeds/S)
+	S.lifespan = value
+
+
+/datum/plant_gene/core/endurance
+	name = "Endurance"
+	value = 15
+
+/datum/plant_gene/core/endurance/apply_stat(obj/item/seeds/S)
+	S.endurance = value
+
+
+/datum/plant_gene/core/production
+	name = "Production Speed"
+	value = 6
+
+/datum/plant_gene/core/production/apply_stat(obj/item/seeds/S)
+	S.production = value
+
+
+/datum/plant_gene/core/yield
+	name = "Yield"
+	value = 3
+
+/datum/plant_gene/core/yield/apply_stat(obj/item/seeds/S)
+	S.yield = value
+
+
+/datum/plant_gene/core/potency
+	name = "Potency"
+	value = 10
+
+/datum/plant_gene/core/potency/apply_stat(obj/item/seeds/S)
+	S.potency = value
+
+/datum/plant_gene/core/instability
+	name = "Stability"
+	value = 10
+
+/datum/plant_gene/core/instability/apply_stat(obj/item/seeds/S)
+	S.instability = value
+
+/datum/plant_gene/core/weed_rate
+	name = "Weed Growth Rate"
+	value = 1
+
+/datum/plant_gene/core/weed_rate/apply_stat(obj/item/seeds/S)
+	S.weed_rate = value
+
+
+/datum/plant_gene/core/weed_chance
+	name = "Weed Vulnerability"
+	value = 5
+
+/datum/plant_gene/core/weed_chance/apply_stat(obj/item/seeds/S)
+	S.weed_chance = value
+
+
+// Reagent genes store reagent ID and reagent ratio. Amount of reagent in the plant = 1 + (potency * rate)
+/datum/plant_gene/reagent
+	name = "Nutriment"
+	var/reagent_id = /datum/reagent/consumable/nutriment
+	var/rate = 0.04
+
+/datum/plant_gene/reagent/get_name()
+	var/formatted_name
+	if(!(mutability_flags & PLANT_GENE_REMOVABLE && mutability_flags & PLANT_GENE_EXTRACTABLE))
+		if(mutability_flags & PLANT_GENE_REMOVABLE)
+			formatted_name += "Fragile "
+		else if(mutability_flags & PLANT_GENE_EXTRACTABLE)
+			formatted_name += "Essential "
+		else
+			formatted_name += "Immutable "
+	formatted_name += "[name] production [rate*100]%"
+	return formatted_name
+
+
+
+/datum/plant_gene/reagent/proc/set_reagent(reag_id)
+	reagent_id = reag_id
+	name = "UNKNOWN"
+
+	var/datum/reagent/R = GLOB.chemical_reagents_list[reag_id]
+	if(R && R.type == reagent_id)
+		name = R.name
+
+/datum/plant_gene/reagent/New(reag_id = null, reag_rate = 0)
+	..()
+	if(reag_id && reag_rate)
+		set_reagent(reag_id)
+		rate = reag_rate
+
+/datum/plant_gene/reagent/Copy()
+	var/datum/plant_gene/reagent/G = ..()
+	G.name = name
+	G.reagent_id = reagent_id
+	G.rate = rate
+	return G
+
+/datum/plant_gene/reagent/can_add(obj/item/seeds/S)
+	if(!..())
+		return FALSE
+	for(var/datum/plant_gene/reagent/R in S.genes)
+		if(R.reagent_id == reagent_id)
+			return FALSE
+	return TRUE
+
+/datum/plant_gene/reagent/polypyr
+	name = "Polypyrylium Oligomers"
+	reagent_id = /datum/reagent/medicine/polypyr
+	rate = 0.15
+
+/datum/plant_gene/reagent/liquidelectricity
+	name = "Liquid Electricity"
+	reagent_id = /datum/reagent/consumable/liquidelectricity
+	rate = 0.1
+
+// Various traits affecting the product. Each must be somehow useful.
+/datum/plant_gene/trait
+	var/rate = 0.05
+	var/examine_line = ""
+	var/trait_id // must be set and equal for any two traits of the same type
+
+/datum/plant_gene/trait/Copy()
+	var/datum/plant_gene/trait/G = ..()
+	G.rate = rate
+	return G
+
+/datum/plant_gene/trait/can_add(obj/item/seeds/S)
+	if(!..())
+		return FALSE
+
+	for(var/datum/plant_gene/trait/R in S.genes)
+		if(trait_id && R.trait_id == trait_id)
+			return FALSE
+		if(type == R.type)
+			return FALSE
+	return TRUE
+
+/datum/plant_gene/trait/proc/on_new(obj/item/reagent_containers/food/snacks/grown/G, newloc)
+	return
+
+/datum/plant_gene/trait/proc/on_consume(obj/item/reagent_containers/food/snacks/grown/G, mob/living/carbon/target)
+	return
+
+/datum/plant_gene/trait/proc/on_slip(obj/item/reagent_containers/food/snacks/grown/G, mob/living/carbon/target)
+	return
+
+/datum/plant_gene/trait/proc/on_squash(obj/item/reagent_containers/food/snacks/grown/G, atom/target)
+	return
+
+/datum/plant_gene/trait/proc/on_attackby(obj/item/reagent_containers/food/snacks/grown/G, obj/item/I, mob/user)
+	return
+
+/datum/plant_gene/trait/proc/on_throw_impact(obj/item/reagent_containers/food/snacks/grown/G, atom/target)
+	return
+
+///This proc triggers when the tray processes and a roll is sucessful, the success chance scales with production.
+/datum/plant_gene/trait/proc/on_grow(obj/machinery/hydroponics/H)
+	return
+
+/datum/plant_gene/trait/squash
+	// Allows the plant to be squashed when thrown or slipped on, leaving a colored mess and trash type item behind.
+	// Also splashes everything in target turf with reagents and applies other trait effects (teleporting, etc) to the target by on_squash.
+	// For code, see grown.dm
+	name = "Liquid Contents"
+	examine_line = "<span class='info'>It has a lot of liquid contents inside.</span>"
+
+/datum/plant_gene/trait/squash/on_slip(obj/item/reagent_containers/food/snacks/grown/G, mob/living/carbon/C)
+	// Squash the plant on slip.
+	G.squash(C)
+
+/datum/plant_gene/trait/slip
+	// Makes plant slippery, unless it has a grown-type trash. Then the trash gets slippery.
+	// Applies other trait effects (teleporting, etc) to the target by on_slip.
+	name = "Slippery Skin"
+	rate = 1.6
+	examine_line = "<span class='info'>It has a very slippery skin.</span>"
+
+/datum/plant_gene/trait/slip/on_new(obj/item/reagent_containers/food/snacks/grown/G, newloc)
+	..()
+	if(istype(G) && ispath(G.trash, /obj/item/grown))
+		return
+	var/obj/item/seeds/seed = G.seed
+	var/stun_len = seed.potency * rate
+
+	if(!istype(G, /obj/item/grown/bananapeel) && (!G.reagents || !G.reagents.has_reagent(/datum/reagent/lube)))
+		stun_len /= 3
+
+	G.AddComponent(/datum/component/slippery, min(stun_len,140), NONE, CALLBACK(src, .proc/handle_slip, G))
+
+/datum/plant_gene/trait/slip/proc/handle_slip(obj/item/reagent_containers/food/snacks/grown/G, mob/M)
+	for(var/datum/plant_gene/trait/T in G.seed.genes)
+		T.on_slip(G, M)
+
+/datum/plant_gene/trait/cell_charge
+	// Cell recharging trait. Charges all mob's power cells to (potency*rate)% mark when eaten.
+	// Generates sparks on squash.
+	// Small (potency*rate*5) chance to shock squish or slip target for (potency*rate*5) damage.
+	// Also affects plant batteries see capatative cell production datum
+	name = "Electrical Activity"
+	rate = 0.2
+
+/datum/plant_gene/trait/cell_charge/on_slip(obj/item/reagent_containers/food/snacks/grown/G, mob/living/carbon/C)
+	var/power = G.seed.potency*rate
+	if(prob(power))
+		C.electrocute_act(round(power), G, 1, SHOCK_NOGLOVES)
+
+/datum/plant_gene/trait/cell_charge/on_squash(obj/item/reagent_containers/food/snacks/grown/G, atom/target)
+	if(iscarbon(target))
+		var/mob/living/carbon/C = target
+		var/power = G.seed.potency*rate
+		if(prob(power))
+			C.electrocute_act(round(power), G, 1, SHOCK_NOGLOVES)
+
+/datum/plant_gene/trait/cell_charge/on_consume(obj/item/reagent_containers/food/snacks/grown/G, mob/living/carbon/target)
+	if(!G.reagents.total_volume)
+		var/batteries_recharged = 0
+		for(var/obj/item/stock_parts/cell/C in target.GetAllContents())
+			var/newcharge = min(G.seed.potency*0.01*C.maxcharge, C.maxcharge)
+			if(C.charge < newcharge)
+				C.charge = newcharge
+				if(isobj(C.loc))
+					var/obj/O = C.loc
+					O.update_icon() //update power meters and such
+				C.update_icon()
+				batteries_recharged = 1
+		if(batteries_recharged)
+			to_chat(target, "<span class='notice'>Your batteries are recharged!</span>")
+
+
+
+/datum/plant_gene/trait/glow
+	// Makes plant glow. Makes plant in tray glow too.
+	// Adds 1 + potency*rate light range and potency*(rate + 0.01) light_power to products.
+	name = "Bioluminescence"
+	rate = 0.03
+	examine_line = "<span class='info'>It emits a soft glow.</span>"
+	trait_id = "glow"
+	var/glow_color = "#C3E381"
+
+/datum/plant_gene/trait/glow/proc/glow_range(obj/item/seeds/S)
+	return 1.4 + S.potency*rate
+
+/datum/plant_gene/trait/glow/proc/glow_power(obj/item/seeds/S)
+	return max(S.potency*(rate + 0.01), 0.1)
+
+/datum/plant_gene/trait/glow/on_new(obj/item/reagent_containers/food/snacks/grown/G, newloc)
+	..()
+	G.set_light(glow_range(G.seed), glow_power(G.seed), glow_color)
+
+/datum/plant_gene/trait/glow/shadow
+	//makes plant emit slightly purple shadows
+	name = "Shadow Emission"
+	rate = 0.04
+	glow_color = "#AAD84B"
+
+/datum/plant_gene/trait/glow/shadow/glow_power(obj/item/seeds/S)
+	return -max(S.potency*(rate*0.2), 0.2)
+
+/datum/plant_gene/trait/glow/white
+	name = "White Bioluminescence"
+	glow_color = "#FFFFFF"
+
+/datum/plant_gene/trait/glow/red
+	//Colored versions of bioluminescence.
+	name = "Red Bioluminescence"
+	glow_color = "#FF3333"
+
+/datum/plant_gene/trait/glow/yellow
+	//not the disgusting glowshroom yellow hopefully
+	name = "Yellow Bioluminescence"
+	glow_color = "#FFFF66"
+
+/datum/plant_gene/trait/glow/green
+	//oh no, now i'm radioactive
+	name = "Green Bioluminescence"
+	glow_color = "#99FF99"
+
+/datum/plant_gene/trait/glow/blue
+	//the best one
+	name = "Blue Bioluminescence"
+	glow_color = "#6699FF"
+
+/datum/plant_gene/trait/glow/purple
+	//did you know that notepad++ doesnt think bioluminescence is a word
+	name = "Purple Bioluminescence"
+	glow_color = "#D966FF"
+
+/datum/plant_gene/trait/glow/pink
+	//gay tide station pride
+	name = "Pink Bioluminescence"
+	glow_color = "#FFB3DA"
+
+
+
+// Bluespace mutation was here and removed.
+
+/datum/plant_gene/trait/maxchem
+	// 2x to max reagents volume.
+	name = "Densified Chemicals"
+	rate = 2
+
+/datum/plant_gene/trait/maxchem/on_new(obj/item/reagent_containers/food/snacks/grown/G, newloc)
+	..()
+	G.reagents.maximum_volume *= rate
+
+/datum/plant_gene/trait/repeated_harvest
+	name = "Perennial Growth"
+
+/datum/plant_gene/trait/repeated_harvest/can_add(obj/item/seeds/S)
+	if(!..())
+		return FALSE
+	if(istype(S, /obj/item/seeds/replicapod))
+		return FALSE
+	return TRUE
+
+/datum/plant_gene/trait/battery
+	name = "Capacitive Cell Production"
+
+/datum/plant_gene/trait/battery/on_attackby(obj/item/reagent_containers/food/snacks/grown/G, obj/item/I, mob/user)
+	if(istype(I, /obj/item/stack/cable_coil))
+		if(I.use_tool(src, user, 0, 5, skill_gain_mult = TRIVIAL_USE_TOOL_MULT))
+			to_chat(user, "<span class='notice'>You add some cable to [G] and slide it inside the battery encasing.</span>")
+			var/obj/item/stock_parts/cell/potato/pocell = new /obj/item/stock_parts/cell/potato(user.loc)
+			pocell.icon_state = G.icon_state
+			pocell.maxcharge = G.seed.potency * 20
+
+			// The secret of potato supercells!
+			var/datum/plant_gene/trait/cell_charge/CG = G.seed.get_gene(/datum/plant_gene/trait/cell_charge)
+			if(CG) // Cell charge max is now 40MJ or otherwise known as 400KJ (Same as bluespace powercells)
+				pocell.maxcharge *= CG.rate*100
+			pocell.charge = pocell.maxcharge
+			pocell.name = "[G.name] battery"
+			pocell.desc = "A rechargeable plant-based power cell. This one has a rating of [DisplayEnergy(pocell.maxcharge)], and you should not swallow it."
+
+			if(G.reagents.has_reagent(/datum/reagent/toxin/plasma, 2))
+				pocell.rigged = TRUE
+
+			qdel(G)
+		else
+			to_chat(user, "<span class='warning'>You need five lengths of cable to make a [G] battery!</span>")
+
+
+/datum/plant_gene/trait/stinging
+	name = "Hypodermic Prickles"
+
+/datum/plant_gene/trait/stinging/on_throw_impact(obj/item/reagent_containers/food/snacks/grown/G, atom/target)
+	if(isliving(target) && G.reagents && G.reagents.total_volume)
+		var/mob/living/L = target
+		if(L.reagents && L.can_inject(null, 0))
+			var/injecting_amount = max(1, G.seed.potency*0.2) // Minimum of 1, max of 20
+			var/fraction = min(injecting_amount/G.reagents.total_volume, 1)
+			G.reagents.reaction(L, INJECT, fraction)
+			G.reagents.trans_to(L, injecting_amount)
+			to_chat(target, "<span class='danger'>You are pricked by [G]!</span>")
+
+/datum/plant_gene/trait/smoke
+	name = "gaseous decomposition"
+
+/datum/plant_gene/trait/smoke/on_squash(obj/item/reagent_containers/food/snacks/grown/G, atom/target)
+	var/datum/effect_system/smoke_spread/chem/S = new
+	var/splat_location = get_turf(target)
+	var/smoke_amount = round(sqrt(G.seed.potency * 0.1), 1)
+	S.attach(splat_location)
+	S.set_up(G.reagents, smoke_amount, splat_location, 0)
+	S.start()
+	G.reagents.clear_reagents()
+
+/datum/plant_gene/trait/fire_resistance // Lavaland
+	name = "Fire Resistance"
+
+/datum/plant_gene/trait/fire_resistance/apply_vars(obj/item/seeds/S)
+	if(!(S.resistance_flags & FIRE_PROOF))
+		S.resistance_flags |= FIRE_PROOF
+
+/datum/plant_gene/trait/fire_resistance/on_new(obj/item/reagent_containers/food/snacks/grown/G, newloc)
+	if(!(G.resistance_flags & FIRE_PROOF))
+		G.resistance_flags |= FIRE_PROOF
+
+//Invasive spreading lets the plant jump to other trays, the spreadinhg plant won't replace plants of the same type.
+/datum/plant_gene/trait/invasive
+	name = "Invasive Spreading"
+
+/datum/plant_gene/trait/invasive/on_grow(obj/machinery/hydroponics/H)
+	for(var/step_dir in GLOB.alldirs)
+		var/obj/machinery/hydroponics/HY = locate() in get_step(H, step_dir)
+		if(HY && prob(15))
+			if(HY.myseed) // check if there is something in the tray.
+				if(HY.myseed.type == H.myseed.type && HY.dead != 0)
+					continue //It should not destroy its owm kind.
+				qdel(HY.myseed)
+				HY.myseed = null
+			HY.myseed = H.myseed.Copy()
+			HY.age = 0
+			HY.dead = 0
+			HY.plant_health = HY.myseed.endurance
+			HY.lastcycle = world.time
+			HY.harvest = 0
+			HY.weedlevel = 0 // Reset
+			HY.pestlevel = 0 // Reset
+			HY.update_icon()
+			HY.visible_message("<span class='warning'>The [H.myseed.plantname] spreads!</span>")
+
+/datum/plant_gene/trait/plant_type // Parent type
+	name = "you shouldn't see this"
+	trait_id = "plant_type"
+
+/datum/plant_gene/trait/plant_type/weed_hardy
+	name = "Weed Adaptation"
+
+/datum/plant_gene/trait/plant_type/fungal_metabolism
+	name = "Fungal Vitality"
+
+/datum/plant_gene/trait/plant_type/alien_properties
+	name ="?????"
+
+/datum/plant_gene/trait/plant_type/carnivory
+	name = "Obligate Carnivory"
+


### PR DESCRIPTION
- Adds a extra point to Poor Aim (because you can't shoot in a straight line)
- Fixes Monophobia to be less retarded with a depression mood event
- Removes Phobia negative quirk due to it's retardness
- Moves Cannibal Quirk to neutral quirks

Closes #91 