### PR TITLE
legion loadout changes

### DIFF
--- a/code/modules/jobs/job_types/legion.dm
+++ b/code/modules/jobs/job_types/legion.dm
@@ -318,15 +318,16 @@ commented out pending rework*/
 		/obj/item/gun/ballistic/revolver/colt357 = 1,
 		/obj/item/restraints/handcuffs = 1,
 		/obj/item/storage/bag/money/small/legofficers = 1,
+		/obj/item/binoculars
 		)
 
 /datum/outfit/loadout/decvetfront
 	name = "Lead from the front"
 	head = /obj/item/clothing/head/helmet/f13/legion/heavy
-	suit_store = /obj/item/twohanded/fireaxe
+	suit_store = /obj/item/twohanded/spear/lance
 	backpack_contents = list(
-		/obj/item/gun/ballistic/automatic/smg/cg45 = 1,
-		/obj/item/ammo_box/magazine/cg45 = 2,
+		/obj/item/gun/ballistic/automatic/smg/greasegun = 1,
+		/obj/item/ammo_box/magazine/greasegun = 2,
 		/obj/item/grenade/smokebomb = 1,
 		)
 
@@ -394,13 +395,14 @@ commented out pending rework*/
 		/obj/item/melee/onehanded/machete/gladius = 1,
 		/obj/item/storage/bag/money/small/legofficers = 1,
 		/obj/item/grenade/smokebomb = 1,
+		/obj/item/binoculars,
 		)
 
 /datum/outfit/loadout/decprimfront
 	name = "Lead from the front"
-	suit_store = /obj/item/gun/ballistic/automatic/smg/greasegun
+	suit_store = /obj/item/gun/ballistic/automatic/smg/mini_uzi
 	backpack_contents = list(
-		/obj/item/ammo_box/magazine/greasegun = 2,
+		/obj/item/ammo_box/magazine/uzim9mm = 2,
 		)
 
 /datum/outfit/loadout/decprimrear
@@ -578,8 +580,8 @@ commented out pending rework*/
 	exp_requirements = 300
 
 	loadout_options = list(
-		/datum/outfit/loadout/expsniper,	// Scoped Hunting rifle, .45 Revolver, Machete, Smokebomb, Polarized goggles
-		/datum/outfit/loadout/expambusher,	// Lever shotgun, .45 Revolver, Bottlecap mine, Machete
+		/datum/outfit/loadout/expsniper,	// sniper rifle, .45 Revolver, Machete, Smokebomb
+		/datum/outfit/loadout/expambusher,	// mp5, .45 revolver, Bottlecap mine, Machete
 		)
 
 	matchmaking_allowed = list(
@@ -597,7 +599,6 @@ commented out pending rework*/
 		return
 	ADD_TRAIT(H, TRAIT_HARD_YARDS, src)
 	ADD_TRAIT(H, TRAIT_BIG_LEAGUES, src)
-	ADD_TRAIT(H, TRAIT_LIFEGIVER, src)
 
 /datum/outfit/job/CaesarsLegion/Legionnaire/f13explorer
 	name = "Legion Explorer"
@@ -618,21 +619,20 @@ commented out pending rework*/
 
 /datum/outfit/loadout/expambusher
 	name = "Ambusher"
-	suit_store = /obj/item/gun/ballistic/shotgun/automatic/combat/shotgunlever
-	glasses = /obj/item/clothing/glasses/night/polarizing
+	suit_store = /obj/item/gun/ballistic/automatic/smg/mp5
+	glasses = /obj/item/clothing/glasses/sunglasses/big
 	backpack_contents = list(
-		/obj/item/ammo_box/shotgun/buck = 1,
-		/obj/item/ammo_box/shotgun/slug = 1,
+		/obj/item/ammo_box/magazine/uzim9mm = 2,
 		/obj/item/bottlecap_mine = 1,
 		)
 
 /datum/outfit/loadout/expsniper
 	name = "Sniper"
-	glasses = /obj/item/clothing/glasses/night/polarizing
+	glasses = /obj/item/clothing/glasses/sunglasses/big
 	l_pocket = /obj/item/attachments/scope
-	suit_store = /obj/item/gun/ballistic/rifle/repeater/brush
+	suit_store = /obj/item/gun/ballistic/automatic/marksman/sniper,
 	backpack_contents = list(
-		/obj/item/ammo_box/tube/c4570 = 3,
+		/obj/item/ammo_box/magazine/m762 = 3,
 		/obj/item/melee/onehanded/machete = 1,
 		/obj/item/grenade/smokebomb = 1,
 		)
@@ -700,9 +700,9 @@ commented out pending rework*/
 	suit_store = /obj/item/gun/ballistic/revolver/m29
 	backpack_contents = list(
 		/obj/item/ammo_box/m44 = 3,
-		/obj/item/melee/onehanded/machete/gladius= 1,
-		/obj/item/shield/riot/legion= 1,
-		/obj/item/stack/crafting/armor_plate= 1,
+		/obj/item/melee/onehanded/machete/gladius = 1,
+		/obj/item/shield/riot/legion = 1,
+		/obj/item/stack/crafting/armor_plate = 1,
 		)
 
 /datum/outfit/loadout/vetrifle
@@ -719,8 +719,8 @@ commented out pending rework*/
 	backpack_contents = list(
 		/obj/item/ammo_box/shotgun/slug = 1,
 		/obj/item/ammo_box/shotgun/buck = 1,
-		/obj/item/twohanded/fireaxe = 1,
-		/obj/item/restraints/legcuffs/bola = 1,
+		/obj/item/twohanded/spear/lance = 1,
+		/obj/item/restraints/legcuffs/bola = 2,
 		)
 
 
@@ -758,7 +758,6 @@ commented out pending rework*/
 	if(visualsOnly)
 		return
 	ADD_TRAIT(H, TRAIT_BIG_LEAGUES, src)
-	ADD_TRAIT(H, TRAIT_HARD_YARDS, src)
 
 /datum/outfit/job/CaesarsLegion/Legionnaire/f13legionary
 	name = "Prime Legionnaire"
@@ -778,12 +777,13 @@ commented out pending rework*/
 
 /datum/outfit/loadout/primelancer
 	name = "Frontliner"
-	suit_store = /obj/item/gun/ballistic/revolver/revolver45
-	r_hand = /obj/item/shield/riot/buckler
+	suit_store = /obj/item/gun/ballistic/automatic/pistol/n99
+	r_hand = /obj/item/shield/riot/legion
 	backpack_contents = list(
-		/obj/item/ammo_box/c45/improvised = 3,
+		/obj/item/ammo_box/magazine/m10mm_adv = 2,
 		/obj/item/restraints/legcuffs/bola = 1,
 		/obj/item/melee/onehanded/machete/forgedmachete = 1,
+		/obj/item/book/granter/trait/trekking = 1,
 		)
 
 /datum/outfit/loadout/primerifle
@@ -836,7 +836,7 @@ commented out pending rework*/
 	. = ..()
 	if(visualsOnly)
 		return
-	ADD_TRAIT(H, TRAIT_HARD_YARDS, src)
+	ADD_TRAIT(H, TRAIT_BIG_LEAGUES, src)
 
 /datum/outfit/job/CaesarsLegion/Legionnaire/f13recleg
 	name = "Recruit Legionnaire"
@@ -855,10 +855,10 @@ commented out pending rework*/
 
 /datum/outfit/loadout/recruittribal
 	name = "Tribal Recruit"
-	suit_store = /obj/item/twohanded/spear/lance
+	suit_store = /obj/item/twohanded/fireaxe
 	backpack_contents = list(
-		/obj/item/book/granter/trait/bigleagues = 1,
 		/obj/item/restraints/legcuffs/bola = 1,
+		/obj/item/book/granter/trait/trekking = 1,
 		)
 
 /datum/outfit/loadout/recruitlegion

--- a/code/modules/jobs/job_types/legion.dm
+++ b/code/modules/jobs/job_types/legion.dm
@@ -193,7 +193,7 @@ Weapons		Lever shotgun, Grease gun, Repeater carbines, Revolvers, simple guns al
 	loadout_options = list(
 		/datum/outfit/loadout/palacent,		// M1919, military ripper
 		/datum/outfit/loadout/rangerhunter,	// Hunting revolver, AMR
-		/datum/outfit/loadout/centurion,	// 10mm SMG, Powerfist
+		/datum/outfit/loadout/centurion,	// 14mm pistol, Powerfist
 		)
 
 /datum/outfit/job/CaesarsLegion/Legionnaire/f13centurion/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
@@ -251,10 +251,10 @@ Weapons		Lever shotgun, Grease gun, Repeater carbines, Revolvers, simple guns al
 	name = "Frontline Centurion"
 	suit = /obj/item/clothing/suit/armor/f13/legion/centurion
 	head = /obj/item/clothing/head/helmet/f13/legion/centurion
-	suit_store = /obj/item/gun/ballistic/automatic/smg/smg10mm
+	suit_store = /obj/item/gun/ballistic/automatic/pistol/pistol14
 	backpack_contents = list(
 		/obj/item/melee/powerfist/goliath = 1,
-		/obj/item/ammo_box/magazine/m10mm_adv/ext = 2,
+		/obj/item/ammo_box/magazine/m14mm = 3,
 		/obj/item/tank/internals/oxygen = 1
 		)
 
@@ -324,7 +324,7 @@ commented out pending rework*/
 /datum/outfit/loadout/decvetfront
 	name = "Lead from the front"
 	head = /obj/item/clothing/head/helmet/f13/legion/heavy
-	suit_store = /obj/item/twohanded/spear/lance
+	suit_store = /obj/item/twohanded/sledgehammer/supersledge
 	backpack_contents = list(
 		/obj/item/gun/ballistic/automatic/smg/greasegun = 1,
 		/obj/item/ammo_box/magazine/greasegun = 2,
@@ -400,9 +400,9 @@ commented out pending rework*/
 
 /datum/outfit/loadout/decprimfront
 	name = "Lead from the front"
-	suit_store = /obj/item/gun/ballistic/automatic/smg/mini_uzi
+	suit_store = /obj/item/gun/ballistic/automatic/smg/smg10mm
 	backpack_contents = list(
-		/obj/item/ammo_box/magazine/uzim9mm = 2,
+		/obj/item/ammo_box/magazine/m10mm_adv/ext = 2,
 		)
 
 /datum/outfit/loadout/decprimrear
@@ -558,9 +558,9 @@ commented out pending rework*/
 /datum/outfit/loadout/vexfox
 	name = "Desert Fox"
 	head = /obj/item/clothing/head/helmet/f13/legion/vet/vexil
-	suit_store = /obj/item/gun/ballistic/automatic/marksman/sniper
+	suit_store = /obj/item/gun/ballistic/automatic/smg/smg10mm
 	backpack_contents = list(
-		/obj/item/ammo_box/magazine/w308 = 3,
+		/obj/item/ammo_box/magazine/m10mm_adv/ext = 2,
 		/obj/item/melee/onehanded/machete/gladius = 1,
 		)
 

--- a/code/modules/jobs/job_types/legion.dm
+++ b/code/modules/jobs/job_types/legion.dm
@@ -629,8 +629,7 @@ commented out pending rework*/
 /datum/outfit/loadout/expsniper
 	name = "Sniper"
 	glasses = /obj/item/clothing/glasses/sunglasses/big
-	l_pocket = /obj/item/attachments/scope
-	suit_store = /obj/item/gun/ballistic/automatic/marksman/sniper,
+	suit_store = /obj/item/gun/ballistic/automatic/marksman/sniper
 	backpack_contents = list(
 		/obj/item/ammo_box/magazine/m762 = 3,
 		/obj/item/melee/onehanded/machete = 1,

--- a/code/modules/jobs/job_types/legion.dm
+++ b/code/modules/jobs/job_types/legion.dm
@@ -334,10 +334,10 @@ commented out pending rework*/
 /datum/outfit/loadout/decvetrear
 	name = "Lead from the rear"
 	head = /obj/item/clothing/head/helmet/f13/legion/vet/decan
-	suit_store = /obj/item/gun/ballistic/automatic/m1garand/sks
+	suit_store = /obj/item/gun/ballistic/rifle/repeater/brush
 	backpack_contents = list(
 		/obj/item/melee/onehanded/machete/spatha = 1,
-		/obj/item/ammo_box/magazine/sks = 3,
+		/obj/item/ammo_box/tube/c4570 = 3,
 		)
 
 


### PR DESCRIPTION
### About The Pull Request

Right so after discovering legion explorers starts with a brushgun, i went on to change that. I then tweaked a lot of the legion loadouts making some a little weaker and others a little stronger, overall making the legion weaker. (after some tweaks its kind of a legion buff to some degrees)
### Why It's Good For The Game
makes the explorers not completly busted and also fixes some issues brought on by legion players about recruit legion melee and vet legion melee

### Pre-Merge Checklist

- [x]  Your Pull Request contains no breaking changes
- [x]  You tested your changes locally, and they work.
- [x] There are no new Runtimes that appear.
- [x] You documented all of your changes.

**Changelog**
🆑balanced: the explorers snipers now get a sniper rifle instead of a brush gun, their night vision was also removed, their other loadout was changed from a lever action shotgun to a mp5 smg. recruits and prime legion doesnt get hard yard anymore, instead their melee loadout have a trekking book. legion recruits now get a fireaxe instead of a lance. legion prime frontliner now get a legion shield, a 10mm pistol and the trekking book. legion veterans berserker now get a legion lance instead of a fire axe. legion prime decanus now gets a 10mm smg instead of a grease gun. legion vet decanus now gets a super sledge instead of a fire axe and a grease gun instead of a carl gustav. vet decanus now gets a brush gun instead of a sks. vet now gets a 10mm smg instead of a sniper rifle. centurion has his 10mm smg replaced with a 14mm pistol. vex now gets a 10mm smg instead of s sniper rifle