### PR TITLE
Upgrade lighting sybsystem

### DIFF
--- a/code/controllers/subsystem/lighting.dm
+++ b/code/controllers/subsystem/lighting.dm
@@ -32,17 +32,19 @@ SUBSYSTEM_DEF(lighting)
 	if(!init_tick_checks)
 		MC_SPLIT_TICK
 	var/i = 0
-	for (i in 1 to GLOB.lighting_update_lights.len)
-		var/datum/light_source/L = GLOB.lighting_update_lights[i]
+	var/light_update_length = GLOB.lighting_update_lights.len
+	if (light_update_length)
+		for (i in 1 to light_update_length)
+			var/datum/light_source/L = GLOB.lighting_update_lights[i]
 
-		L.update_corners()
+			L.update_corners()
 
-		L.needs_update = LIGHTING_NO_UPDATE
+			L.needs_update = LIGHTING_NO_UPDATE
 
-		if(init_tick_checks)
-			CHECK_TICK
-		else if (MC_TICK_CHECK)
-			break
+			if(init_tick_checks)
+				CHECK_TICK
+			else if (MC_TICK_CHECK)
+				break
 	if (i)
 		GLOB.lighting_update_lights.Cut(1, i+1)
 		i = 0

--- a/code/controllers/subsystem/lighting.dm
+++ b/code/controllers/subsystem/lighting.dm
@@ -31,58 +31,52 @@ SUBSYSTEM_DEF(lighting)
 	MC_SPLIT_TICK_INIT(3)
 	if(!init_tick_checks)
 		MC_SPLIT_TICK
-	var/i = 0
-	var/light_update_length = GLOB.lighting_update_lights.len
-	if (light_update_length)
-		for (i in 1 to light_update_length)
-			var/datum/light_source/L = GLOB.lighting_update_lights[i]
+	var/list/queue = GLOB.lighting_update_lights
+	while(length(queue))
+		var/datum/light_source/light_datum = queue[length(queue)]
+		queue.len--
 
-			L.update_corners()
+		light_datum.update_corners()
 
-			L.needs_update = LIGHTING_NO_UPDATE
+		light_datum.needs_update = LIGHTING_NO_UPDATE
 
-			if(init_tick_checks)
-				CHECK_TICK
-			else if (MC_TICK_CHECK)
-				break
-	if (i)
-		GLOB.lighting_update_lights.Cut(1, i+1)
-		i = 0
-
-	if(!init_tick_checks)
-		MC_SPLIT_TICK
-
-	for (i in 1 to GLOB.lighting_update_corners.len)
-		var/datum/lighting_corner/C = GLOB.lighting_update_corners[i]
-
-		C.update_objects()
-		C.needs_update = FALSE
 		if(init_tick_checks)
 			CHECK_TICK
 		else if (MC_TICK_CHECK)
 			break
-	if (i)
-		GLOB.lighting_update_corners.Cut(1, i+1)
-		i = 0
-
 
 	if(!init_tick_checks)
 		MC_SPLIT_TICK
 
-	for (i in 1 to GLOB.lighting_update_objects.len)
-		var/atom/movable/lighting_object/O = GLOB.lighting_update_objects[i]
+	queue = GLOB.lighting_update_corners
+	while(length(queue))
+		var/datum/lighting_corner/corner_datum = queue[length(queue)]
+		queue.len--
 
-		if (QDELETED(O))
+		corner_datum.update_objects()
+		corner_datum.needs_update = FALSE
+		if(init_tick_checks)
+			CHECK_TICK
+		else if (MC_TICK_CHECK)
+			break
+
+	if(!init_tick_checks)
+		MC_SPLIT_TICK
+
+	queue = GLOB.lighting_update_objects
+	while(length(queue))
+		var/atom/movable/lighting_object/lighting_object = queue[length(queue)]
+		queue.len--
+
+		if (QDELETED(lighting_object))
 			continue
 
-		O.update()
-		O.needs_update = FALSE
+		lighting_object.update()
+		lighting_object.needs_update = FALSE
 		if(init_tick_checks)
 			CHECK_TICK
 		else if (MC_TICK_CHECK)
 			break
-	if (i)
-		GLOB.lighting_update_objects.Cut(1, i+1)
 
 
 /datum/controller/subsystem/lighting/Recover()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Testmerge of #119 revealed a bit of a problem with the lighting subsystem, likely due to the fact that it's a whole new z-level with a fair few more lights. Sometimes when the lighting subsystem fires for the very first time, there's going to be a discrepancy between when it first checks the length of GLOB.lighting_update_lights and when it's actually used. This was causing it to runtime and fail outright, requiring a restart to fix. This PR gives the lighting subsystem its own queues to work with to avoid this edge case.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Runtimes bad.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Pre-Merge Checklist
- [x] Your Pull Request contains no breaking changes
- [x] You tested your changes locally, and they work.
- [x] There are no new Runtimes that appear.
- [x] You documented all of your changes.

<!-- Please check these accordingly. -->

## Changelog
:cl: 0xEFF
fix: Give the lighting system a bit of a sanity check
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
