### PR TITLE
Melee weapon rework (buff)

### DIFF
--- a/code/game/objects/items/melee/f13onehanded.dm
+++ b/code/game/objects/items/melee/f13onehanded.dm
@@ -31,8 +31,7 @@
 	desc = "A makeshift machete made of a lawn mower blade."
 	icon_state = "machete_imp"
 	item_state = "salvagedmachete"
-	force = 34
-	block_chance = 7
+	force = 40
 	throwforce = 20
 	sharpness = SHARP_EDGED
 
@@ -40,8 +39,7 @@
 	name = "machete"
 	desc = "A forged machete made of high quality steel."
 	icon_state = "machete"
-	force = 35
-	block_chance = 8
+	force = 45
 
 /obj/item/melee/onehanded/machete/training
 	name = "training machete"
@@ -49,7 +47,6 @@
 	icon_state = "machete_training"
 	force = 1
 	throwforce = 5
-	block_chance = 8
 
 /obj/item/melee/onehanded/machete/training/attack(mob/living/M, mob/living/user)
 	. = ..()
@@ -62,32 +59,28 @@
 	desc = "A heavy cutting blade, made for war and mass produced in Legion territory."
 	icon_state = "gladius"
 	item_state = "gladius"
-	force = 36
-	block_chance = 10
+	force = 50
 
 /obj/item/melee/onehanded/machete/spatha
 	name = "spatha"
 	desc = "This long blade is favoured by Legion officers and leaders, a finely crafted weapon with good steel and hilt made from bronze and bone."
 	icon_state = "spatha"
 	item_state = "spatha"
-	force = 38
-	block_chance = 18
+	force = 55
 
 /obj/item/melee/onehanded/machete/spatha/longblade
 	name = "forged claymore"
 	desc = "A long one-handed blade sporting lovingly applied wraps and a wonderfully forged and engraved guard. The blade looks to be carefully sharpened."
 	icon_state = "longblade"
 	item_state = "longblade"
-	force = 38
-	block_chance = 18
+	force = 55
 
 /obj/item/melee/onehanded/machete/scrapsabre
 	name = "scrap sabre"
 	desc = "Made from materials found in the wastes, a skilled blacksmith has turned it into a thing of deadly beauty."
 	icon_state = "scrapsabre"
 	item_state = "scrapsabre"
-	force = 37
-	block_chance = 15
+	force = 40
 
 /obj/item/throwing_star/spear
 	name = "throwing spear"
@@ -98,11 +91,11 @@
 	item_state = "tribalspear"
 	force = 20
 	throwforce = 35
-	armour_penetration = 0.10
+	armour_penetration = 0.15
 	max_reach = 2
 	item_flags = SLOWS_WHILE_IN_HAND
 	slowdown = 0.3
-	embedding = list("pain_mult" = 2, "embed_chance" = 60, "fall_chance" = 20)
+	embedding = list("pain_mult" = 2, "embed_chance" = 60, "fall_chance" = 25)
 	w_class = WEIGHT_CLASS_NORMAL
 
 
@@ -119,7 +112,6 @@
 	w_class = WEIGHT_CLASS_SMALL
 	throwforce = 15
 	hitsound = 'sound/weapons/bladeslice.ogg'
-	armour_penetration = 0.05
 	throw_speed = 3
 	throw_range = 6
 	attack_verb = list("slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
@@ -151,8 +143,8 @@
 	name = "hunting knife"
 	icon_state = "knife_hunting"
 	desc = "Dependable hunting knife."
-	embedding = list("pain_mult" = 4, "embed_chance" = 65, "fall_chance" = 10, "ignore_throwspeed_threshold" = TRUE)
-	force = 27
+	embedding = list("pain_mult" = 4, "embed_chance" = 40, "fall_chance" = 20, "ignore_throwspeed_threshold" = TRUE)
+	force = 30
 	throwforce = 25
 	attack_verb = list("slashed", "stabbed", "sliced", "torn", "ripped", "cut")
 
@@ -160,15 +152,15 @@
 	name = "survival knife"
 	icon_state = "knife_survival"
 	desc = "Multi-purpose knife with blackened steel."
-	embedding = list("pain_mult" = 4, "embed_chance" = 35, "fall_chance" = 10)
-	force = 27
+	embedding = list("pain_mult" = 4, "embed_chance" = 35, "fall_chance" = 20)
+	force = 30
 	throwforce = 25
 
 /obj/item/melee/onehanded/knife/bayonet
 	name = "bayonet knife"
 	icon_state = "knife_bayonet"
 	desc = "This weapon is made for stabbing, not much use for other things."
-	force = 26
+	force = 18
 	bayonet = TRUE
 
 /obj/item/melee/onehanded/knife/bowie
@@ -176,7 +168,8 @@
 	icon_state = "knife_bowie"
 	item_state = "knife_bowie"
 	desc = "A large clip point fighting knife."
-	force = 30
+	force = 35
+	armour_penetration = 0.1
 	throwforce = 25
 	attack_verb = list("slashed", "stabbed", "sliced", "shanked", "ripped", "lacerated")
 
@@ -185,7 +178,8 @@
 	icon_state = "knife_trench"
 	item_state = "knife_trench"
 	desc = "This blade is designed for brutal close quarters combat."
-	force = 31
+	force = 38
+	armour_penetration = 0.1
 	custom_materials = list(/datum/material/iron=8000)
 	attack_verb = list("slashed", "stabbed", "sliced", "shanked", "ripped", "lacerated")
 
@@ -196,8 +190,8 @@
 	lefthand_file = 'icons/mob/inhands/weapons/swords_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/swords_righthand.dmi'
 	desc = "A sharpened bone. The bare minimum in survival."
-	embedding = list("pain_mult" = 4, "embed_chance" = 35, "fall_chance" = 10)
-	force = 24
+	embedding = list("pain_mult" = 4, "embed_chance" = 35, "fall_chance" = 20)
+	force = 25
 	throwforce = 20
 	custom_materials = null
 
@@ -207,7 +201,6 @@
 	icon_state = "knife_ritual"
 	item_state = "knife_ritual"
 	force = 25
-	armour_penetration = 0.1
 	custom_materials = null
 
 obj/item/melee/onehanded/knife/switchblade
@@ -219,7 +212,7 @@ obj/item/melee/onehanded/knife/switchblade
 	hitsound = 'sound/weapons/genhit.ogg'
 	attack_verb = list("stubbed", "poked")
 	var/extended = 0
-	var/extended_force = 24
+	var/extended_force = 30
 	var/extended_throwforce = 23
 	var/extended_icon_state = "knife_switch_ext"
 	var/retracted_icon_state = "knife_switch"
@@ -253,7 +246,7 @@ obj/item/melee/onehanded/knife/switchblade
 	desc = "A high-quality kitchen knife made from Saturnite alloy."
 	icon_state = "knife_cosmic_dirty"
 	item_state = "knife"
-	force = 15
+	force = 20
 	throwforce = 10
 	armour_penetration = 0.2
 
@@ -272,7 +265,7 @@ obj/item/melee/onehanded/knife/switchblade
 	icon_state = "knife_cosmic_heated"
 	item_state = "knife"
 	damtype = BURN
-	force = 35
+	force = 25
 	throwforce = 20
 	armour_penetration = 0.4
 
@@ -288,7 +281,8 @@ obj/item/melee/onehanded/knife/switchblade
 	icon_state = "pipe"
 	item_state = "pipe"
 	attack_verb = list("mashed", "bashed", "piped", "hit", "bludgeoned", "whacked", "bonked")
-	force = 26
+	force = 25
+	armour_penetration = 0.1
 	throwforce = 10
 	throw_speed = 3
 	throw_range = 3
@@ -309,8 +303,8 @@ obj/item/melee/onehanded/knife/switchblade
 	item_state = "warclub"
 	attack_verb = list("mashed", "bashed", "hit", "bludgeoned", "whacked")
 	force = 30
+	armour_penetration = 0.3
 	throwforce = 25
-	block_chance = 5
 
 /obj/item/melee/onehanded/club/warclub/attack(mob/living/M, mob/living/user)
 	. = ..()
@@ -324,7 +318,8 @@ obj/item/melee/onehanded/knife/switchblade
 	desc = "A rusty old tire iron, normally used for loosening nuts from car tires.<br>Though it has a short reach, it has decent damage and a fast swing."
 	icon_state = "tire"
 	item_state = "tire"
-	force = 30
+	force = 25
+	armour_penetration = 0.1
 
 // NCR Flag			Keywords: NCR, Damage 26, Stamina damage, Block
 /obj/item/melee/onehanded/club/ncrflag
@@ -334,8 +329,8 @@ obj/item/melee/onehanded/knife/switchblade
 	item_state = "flag-ncr"
 	w_class = WEIGHT_CLASS_BULKY
 	slot_flags = null 
-	force = 26
-	block_chance = 30
+	force = 25
+	armour_penetration = 0.1
 	attack_verb = list("smacked", "thwacked", "democratized", "freedomed")
 
 // Classic Baton
@@ -644,7 +639,7 @@ obj/item/melee/onehanded/knife/switchblade
 	icon_state = "brass"
 	item_state = "brass"
 	attack_verb = list("punched", "jabbed", "whacked")
-	force = 24
+	force = 25
 
 // Spiked knuckles	Keywords: Damage 24
 /obj/item/melee/unarmed/brass/spiked
@@ -653,7 +648,8 @@ obj/item/melee/onehanded/knife/switchblade
 	icon_state = "spiked"
 	item_state = "spiked"
 	sharpness = SHARP_POINTY
-	force = 25
+	force = 28
+	armour_penetration = 0.1
 
 // Sappers			Keywords: Damage 26
 /obj/item/melee/unarmed/sappers
@@ -662,7 +658,8 @@ obj/item/melee/onehanded/knife/switchblade
 	icon_state = "sapper"
 	item_state = "sapper"
 	w_class = WEIGHT_CLASS_NORMAL
-	force = 26
+	force = 28
+	armour_penetration = 0.15
 
 // Tiger claws		Keywords: Damage 28, Pointy
 /obj/item/melee/unarmed/tigerclaw
@@ -673,7 +670,7 @@ obj/item/melee/onehanded/knife/switchblade
 	w_class = WEIGHT_CLASS_NORMAL
 	attack_verb = list("slashed", "sliced", "torn", "ripped", "diced", "cut")
 	sharpness = SHARP_POINTY
-	force = 28
+	force = 30
 	hitsound = 'sound/weapons/bladeslice.ogg'
 
 // Lacerator		Keywords: Damage 27, Edged, Wound bonus
@@ -683,7 +680,7 @@ obj/item/melee/onehanded/knife/switchblade
 	icon_state = "lacerator"
 	item_state = "lacerator"
 	w_class = WEIGHT_CLASS_NORMAL
-	force = 27
+	force = 32
 	bare_wound_bonus = 5
 	sharpness = SHARP_EDGED
 	attack_verb = list("slashed", "sliced", "torn", "ripped", "diced", "cut")
@@ -696,7 +693,8 @@ obj/item/melee/onehanded/knife/switchblade
 	icon_state = "mace_glove"
 	item_state = "mace_glove"
 	w_class = WEIGHT_CLASS_BULKY
-	force = 31
+	force = 25
+	armour_penetration = 0.35
 	sharpness = SHARP_NONE
 
 // Punch Dagger		Keywords: Damage 29, Pointy
@@ -718,8 +716,8 @@ obj/item/melee/onehanded/knife/switchblade
 	item_state = "deathclaw_g"
 	slot_flags = ITEM_SLOT_GLOVES
 	w_class = WEIGHT_CLASS_NORMAL
-	force = 28
-	armour_penetration = 1
+	force = 33
+	armour_penetration = 0.7
 	sharpness = SHARP_EDGED
 	attack_verb = list("slashed", "sliced", "torn", "ripped", "diced", "cut")
 	hitsound = 'sound/weapons/bladeslice.ogg'

--- a/code/game/objects/items/melee/f13powerfist.dm
+++ b/code/game/objects/items/melee/f13powerfist.dm
@@ -42,14 +42,14 @@
 	item_state = "powerfist"
 	lefthand_file = 'icons/mob/inhands/weapons/melee_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/melee_righthand.dmi'
-	force = 30
-	armour_penetration = 0.45
+	force = 10
+	armour_penetration = 0.3
 	mag_type = /obj/item/ammo_box/magazine/internal/shot/dual
 	fire_sound = 'sound/f13weapons/caravan_shotgun.ogg'
 	slot_flags = ITEM_SLOT_BELT | ITEM_SLOT_GLOVES
 	w_class = WEIGHT_CLASS_NORMAL
-	item_flags = NEEDS_PERMIT //doesn't slow you down
-	fire_delay = 0
+	slowdown = 0.1
+	fire_delay = 2.5
 	var/transfer_prints = TRUE //prevents runtimes with forensics when held in glove slot
 
 
@@ -93,10 +93,10 @@
 	slot_flags = ITEM_SLOT_SUITSTORE | ITEM_SLOT_BELT
 	force = 10
 	wound_bonus = 25
-	block_chance = 15
 	throw_speed = 3
 	throw_range = 4
 	throwforce = 10
+	armour_penetration = 0.15
 	tool_behaviour = TOOL_SAW
 	sharpness = SHARP_EDGED
 	toolspeed = 1.5
@@ -105,7 +105,7 @@
 	var/on_item_state = "ripper_on"
 	var/off_item_state = "ripper"
 	var/weight_class_on = WEIGHT_CLASS_HUGE
-	var/force_on = 45
+	var/force_on = 50
 	var/force_off = 10
 	var/on = FALSE
 	var/on_icon_state = "ripper_on"

--- a/code/game/objects/items/melee/f13twohanded.dm
+++ b/code/game/objects/items/melee/f13twohanded.dm
@@ -52,7 +52,7 @@
 /obj/item/twohanded/fireaxe/ComponentInitialize()
 	. = ..()
 	AddComponent(/datum/component/butchering, 100, 80, 0 , hitsound) //axes are not known for being precision butchering tools
-	AddComponent(/datum/component/two_handed, force_unwielded=25, force_wielded=40, icon_wielded="[icon_prefix]2")
+	AddComponent(/datum/component/two_handed, force_unwielded=25, force_wielded=45, icon_wielded="[icon_prefix]2")
 
 /obj/item/twohanded/fireaxe/suicide_act(mob/user)
 	user.visible_message("<span class='suicide'>[user] axes [user.p_them()]self from head to toe! It looks like [user.p_theyre()] trying to commit suicide!</span>")

--- a/code/game/objects/items/melee/f13twohanded.dm
+++ b/code/game/objects/items/melee/f13twohanded.dm
@@ -39,6 +39,7 @@
 	slot_flags = ITEM_SLOT_BACK
 	force = 25
 	throwforce = 15
+	armour_penetration = 0.15
 	wound_bonus = 10
 	bare_wound_bonus = 10
 	sharpness = SHARP_EDGED
@@ -51,7 +52,7 @@
 /obj/item/twohanded/fireaxe/ComponentInitialize()
 	. = ..()
 	AddComponent(/datum/component/butchering, 100, 80, 0 , hitsound) //axes are not known for being precision butchering tools
-	AddComponent(/datum/component/two_handed, force_unwielded=25, force_wielded=45, icon_wielded="[icon_prefix]2")
+	AddComponent(/datum/component/two_handed, force_unwielded=25, force_wielded=40, icon_wielded="[icon_prefix]2")
 
 /obj/item/twohanded/fireaxe/suicide_act(mob/user)
 	user.visible_message("<span class='suicide'>[user] axes [user.p_them()]self from head to toe! It looks like [user.p_theyre()] trying to commit suicide!</span>")
@@ -279,7 +280,7 @@
 
 /obj/item/twohanded/baseball/ComponentInitialize()
 	. = ..()
-	AddComponent(/datum/component/two_handed, force_unwielded = 12, force_wielded = 30, icon_wielded="[icon_prefix]2")
+	AddComponent(/datum/component/two_handed, force_unwielded = 12, force_wielded = 35, icon_wielded="[icon_prefix]2")
 
 /obj/item/twohanded/baseball/attack(mob/living/M, mob/living/user)
 	. = ..()
@@ -294,13 +295,14 @@
 	icon_state = "baseballspike"
 	icon_prefix = "baseballspike"
 	force = 15
+	armour_penetration 0.1
 	throwforce = 15
 	wound_bonus = 5
 	sharpness = SHARP_POINTY
 
 /obj/item/twohanded/baseball/spiked/ComponentInitialize()
 	. = ..()
-	AddComponent(/datum/component/two_handed, force_unwielded = 15, force_wielded = 33, icon_wielded="[icon_prefix]2")
+	AddComponent(/datum/component/two_handed, force_unwielded = 15, force_wielded = 40, icon_wielded="[icon_prefix]2")
 
 
 // Golf Club		Keywords: Damage 15/32, Damage bonus Stamina
@@ -309,6 +311,7 @@
 	desc = "This old and quite heavy 9 iron is bent and battered after many years of use by anyone who found it good enough to break bones and crash skulls."
 	icon_state = "golfclub"
 	icon_prefix = "golfclub"
+	armour_penetration = 0.15
 	attack_verb = list("smashed", "bashed", "fored", "hit", "bludgeoned", "whacked")
 
 /obj/item/twohanded/baseball/golfclub/ComponentInitialize()
@@ -354,13 +357,14 @@
 	attack_speed = CLICK_CD_MELEE * 1.2
 	force = 25
 	throwforce = 30
+	armour_penetration = 0.2
 	slot_flags = ITEM_SLOT_BACK
 	sharpness = SHARP_NONE
 	attack_verb = list("bashed", "pounded", "bludgeoned", "pummeled", "thrashed")
 
 /obj/item/twohanded/sledgehammer/ComponentInitialize()
 	. = ..()
-	AddComponent(/datum/component/two_handed, force_unwielded = 25, force_wielded = 45, icon_wielded="[icon_prefix]2")
+	AddComponent(/datum/component/two_handed, force_unwielded = 25, force_wielded = 40, icon_wielded="[icon_prefix]2")
 
 /*
 /obj/item/twohanded/sledgehammer/afterattack(atom/A, mob/living/user, proximity) //Bonus damage to structures, demolition time
@@ -398,13 +402,14 @@
 	slot_flags = null
 	force = 5
 	throwforce = 20
+	armour_penetration = 0.65
 	throw_speed = 2
 	throw_range = 4
 	attack_verb = list("burned", "welded", "cauterized", "melted", "charred")
 	actions_types = list(/datum/action/item_action/toggle_lance)
 	hitsound = "swing_hit"
 	var/on = FALSE
-	var/force_on = 60
+	var/force_on = 40
 
 /obj/item/twohanded/thermic_lance/ComponentInitialize()
 	. = ..()
@@ -447,8 +452,8 @@
 	w_class = WEIGHT_CLASS_BULKY
 	slot_flags = null
 	force = 20
-	force_on = 32
-	armour_penetration = 0.7
+	force_on = 45
+	armour_penetration = 0.4
 	throwforce = 15
 	throwforce_on = 30
 
@@ -465,10 +470,11 @@
 	icon_state = "hammer-super"
 	icon_prefix = "hammer-super"
 	force = 25
+	armour_penetration = 0.3
 
 obj/item/twohanded/sledgehammer/supersledge/ComponentInitialize()
 	. = ..()
-	AddComponent(/datum/component/two_handed, force_unwielded = 25, force_wielded = 60, icon_wielded="[icon_prefix]2")
+	AddComponent(/datum/component/two_handed, force_unwielded = 25, force_wielded = 55, icon_wielded="[icon_prefix]2")
 
 
 // Rocket-assisted Sledgehammer			Keywords: Damage 20/52, Mining  Issues left: mining only when dual wielded, sound to play always on hit
@@ -480,6 +486,7 @@ obj/item/twohanded/sledgehammer/supersledge/ComponentInitialize()
 	icon_state = "hammer-rocket"
 	icon_prefix = "hammer-rocket"
 	force = 20
+	armour_penetration = 0.2
 	tool_behaviour = TOOL_MINING
 	toolspeed = 0.4
 	hitsound = "sound/f13effects/explosion_distant_2.ogg"
@@ -490,7 +497,7 @@ obj/item/twohanded/sledgehammer/supersledge/ComponentInitialize()
 
 /obj/item/twohanded/sledgehammer/rockethammer/ComponentInitialize()
 	. = ..()
-	AddComponent(/datum/component/two_handed, force_unwielded = 20, force_wielded = 52, icon_wielded="[icon_prefix]2")
+	AddComponent(/datum/component/two_handed, force_unwielded = 20, force_wielded = 45, icon_wielded="[icon_prefix]2")
 
 // The Court Martial	Keywords: UNIQUE, Damage 20/52, Inferior mining
 /obj/item/twohanded/sledgehammer/rockethammer/courtmartial
@@ -510,10 +517,11 @@ obj/item/twohanded/sledgehammer/supersledge/ComponentInitialize()
 	icon_state = "hammer-atom"
 	icon_prefix = "hammer-atom"
 	force = 25
+	armour_penetration = 0.2
 
 /obj/item/twohanded/sledgehammer/atomsjudgement/ComponentInitialize()
 	. = ..()
-	AddComponent(/datum/component/two_handed, force_unwielded = 25, force_wielded = 60, icon_wielded="[icon_prefix]2")
+	AddComponent(/datum/component/two_handed, force_unwielded = 25, force_wielded = 50, icon_wielded="[icon_prefix]2")
 
 /obj/item/twohanded/sledgehammer/atomsjudgement/attack(mob/living/M, mob/living/user)
 	. = ..()
@@ -535,7 +543,7 @@ obj/item/twohanded/sledgehammer/supersledge/ComponentInitialize()
 
 /obj/item/twohanded/sledgehammer/atomsjudgement/ComponentInitialize()
 	. = ..()
-	AddComponent(/datum/component/two_handed, force_unwielded = 25, force_wielded = 45, icon_wielded="[icon_prefix]2")
+	AddComponent(/datum/component/two_handed, force_unwielded = 25, force_wielded = 40, icon_wielded="[icon_prefix]2")
 
 
 // Shaman staff				Keywords: TRIBAL, Damage 15/30
@@ -545,11 +553,12 @@ obj/item/twohanded/sledgehammer/supersledge/ComponentInitialize()
 	icon_state = "staff-shaman"
 	icon_prefix = "staff-shaman"
 	force = 15
+	armour_penetration = 0.1
 	attack_verb = list("bashed", "pounded", "bludgeoned", "pummeled", "thrashed")
 
 /obj/item/twohanded/sledgehammer/shamanstaff/ComponentInitialize()
 	. = ..()
-	AddComponent(/datum/component/two_handed, force_unwielded = 15, force_wielded = 30, icon_wielded="[icon_prefix]2")
+	AddComponent(/datum/component/two_handed, force_unwielded = 15, force_wielded = 35, icon_wielded="[icon_prefix]2")
 
 
 // Staff of Mars			Keywords: Damage 10/10, Damage bonus Burn + Stamina
@@ -599,6 +608,7 @@ obj/item/twohanded/sledgehammer/supersledge/ComponentInitialize()
 	slot_flags = null
 	total_mass = TOTAL_MASS_MEDIEVAL_WEAPON
 	force = 7
+	armour_penetration = 0.1
 	wound_bonus = 25
 	throw_speed = 2
 	throw_range = 2
@@ -614,7 +624,7 @@ obj/item/twohanded/sledgehammer/supersledge/ComponentInitialize()
 	var/off_item_state = "chainsaw"
 	var/weight_class_on = WEIGHT_CLASS_HUGE
 	var/on = FALSE
-	var/force_on = 55
+	var/force_on = 60
 	var/force_off = 7
 	var/description_on = "<span class ='warning'>You pull the cord, starting up the chainsaw with a roar and letting the blades spin up.</span>"
 	var/description_off = "<span class ='notice'>You press the off button, stopping the noise and the carnage.</span>"

--- a/code/game/objects/items/melee/f13twohanded.dm
+++ b/code/game/objects/items/melee/f13twohanded.dm
@@ -295,7 +295,7 @@
 	icon_state = "baseballspike"
 	icon_prefix = "baseballspike"
 	force = 15
-	armour_penetration 0.1
+	armour_penetration = 0.1
 	throwforce = 15
 	wound_bonus = 5
 	sharpness = SHARP_POINTY

--- a/code/game/objects/items/melee/weaponry.dm
+++ b/code/game/objects/items/melee/weaponry.dm
@@ -346,8 +346,8 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	force = 2
 	throwforce = 10 //This is never used on mobs since this has a 100% embed chance.
 	throw_speed = 4
-	embedding = list("pain_mult" = 4, "embed_chance" = 100, "fall_chance" = 0, "embed_chance_turf_mod" = 15)
-	armour_penetration = 0.65
+	embedding = list("pain_mult" = 4, "embed_chance" = 70, "fall_chance" = 10, "embed_chance_turf_mod" = 15)
+	armour_penetration = 0.5
 
 	w_class = WEIGHT_CLASS_SMALL
 	sharpness = SHARP_EDGED


### PR DESCRIPTION
### About The Pull Request

Buffed almost every melee weapons, exceptions being the spears and forged weapons.

**Why It's Good For The Game**

Due to the nature of our armors currently, melee weapons were if not usable, certainly unviable and this PR aims to change that.

### Pre-Merge Checklist

- [x]  Your Pull Request contains no breaking changes
- [x]  You tested your changes locally, and they work.
- [x]  There are no new Runtimes that appear.
- [x]  You documented all of your changes.

### Changelog
🆑 add: 
rebalanced the makeshift machete/scrapsword, forged machete, gladius, spatha/longblade to each do more damages, with a difference of 5 damages in between each "upgrade". rebalanced the fire axe and its childs to do 45 damages with 0.15 ap. rebalanced the sledge hammer to do 40 damages with 0.2 ap. rebalanced all knives to do more damages with a maximum of 0.1 ap. superheated cosmic knives have seen a damage reduction to 25 damages. rebalanced all clubs have seen their damages reduced and gave all of them AP. rebalanced all glove weapons to do either less damages but more ap or more damages but no ap, deathclaw gauntlet has been buffed in damages but its AP reduced to 0.7. throwing spears and shuriken have seen their fall off chance raised. rebalanced the bayonet to do a lot less damages. rebalanced gold clubs and spiked bats to do more ap and damages. rebalanced the super sledge to do slightly less damage but a good ammount of ap. rebalanced the thermal lance to do way less damages but gave it a large ammount of ap. fixed the normal ripper. rebalanced the ballistic fist to have a slowdown, do less damages in range and gave it a slight slowdown. rebalanced the rocket hammers and the war mace and the shaman staff to have their damages reduced and their ap raised. rebalanced the chainsaw to do slightly more damages and gave it 0.1 ap. reduced the proton axe's ap and raised its damages.