### PR TITLE
Centurion Ripper Bugfix

### DIFF
--- a/code/modules/jobs/job_types/legion.dm
+++ b/code/modules/jobs/job_types/legion.dm
@@ -231,7 +231,7 @@ Weapons		Lever shotgun, Grease gun, Repeater carbines, Revolvers, simple guns al
 	head = /obj/item/clothing/head/helmet/f13/legion/palacent
 	suit_store = /obj/item/gun/ballistic/automatic/m1919
 	backpack_contents = list(
-		/obj/item/melee/powered/ripper/prewar,
+		/obj/item/melee/powered/ripper/prewar = 1,
 		/obj/item/ammo_box/magazine/mm762 = 1,
 		)
 


### PR DESCRIPTION
## About The Pull Request

Fixes a very small bug where the Centurion Paladin Slayer loadout did not spawn with the ripper.

## Why It's Good For The Game

Single-line bugfix. I am not going to test this because there's no reason it shouldn't work.

## Pre-Merge Checklist
- [x] Your Pull Request contains no breaking changes
- [x] You tested your changes locally, and they work.
- [x] There are no new Runtimes that appear.
- [x] You documented all of your changes.

<!-- Please check these accordingly. -->

## Changelog
:cl:
fix: Fixed Paladin Slayer loadout not spawning with the ripper.
/:cl: