### PR TITLE
explorer sniper magazine fix

### DIFF
--- a/code/modules/jobs/job_types/legion.dm
+++ b/code/modules/jobs/job_types/legion.dm
@@ -631,7 +631,7 @@ commented out pending rework*/
 	glasses = /obj/item/clothing/glasses/sunglasses/big
 	suit_store = /obj/item/gun/ballistic/automatic/marksman/sniper
 	backpack_contents = list(
-		/obj/item/ammo_box/magazine/m762 = 3,
+		/obj/item/ammo_box/magazine/w308 = 3,
 		/obj/item/melee/onehanded/machete = 1,
 		/obj/item/grenade/smokebomb = 1,
 		)


### PR DESCRIPTION
###About The Pull Request
Replace the sniper rifle magazine from the explorer sniper loadout with the correct mags,
### Why It's Good For The Game
Explorer start with the right magazine for their guns.
### Pre-Merge Checklist

- [x]  Your Pull Request contains no breaking changes
- [x]  You tested your changes locally, and they work.
- [x]  There are no new Runtimes that appear.
- [x] You documented all of your changes.

Changelog
🆑 replaced the magazine that came with the sniper loadout for explorers with the correct one /🆑