### PR TITLE
Adds oxygen tank for SP's powerfist

### DIFF
--- a/code/modules/jobs/job_types/bos.dm
+++ b/code/modules/jobs/job_types/bos.dm
@@ -399,6 +399,7 @@ Star Paladin
 		/obj/item/melee/onehanded/knife/hunting = 1,
 		/obj/item/reagent_containers/hypospray/medipen/stimpak = 2,
 		/obj/item/melee/powerfist = 1,
+		/obj/item/tank/internals/oxygen = 1,
 	)
 
 /datum/outfit/loadout/spaladina


### PR DESCRIPTION
## About The Pull Request

Adds an oxygen tank to the Senior Paladin's loadout.

## Why It's Good For The Game

Powerfists require oxygen tanks to operate at full capacity, and are fairly difficult to acquire in the wasteland. SP should spawn with one; this makes it so he does.

## Pre-Merge Checklist
- [x] Your Pull Request contains no breaking changes
- [ ] You tested your changes locally, and they work.
- [ ] There are no new Runtimes that appear.
- [x] You documented all of your changes.

<!-- Please check these accordingly. -->

## Changelog
:cl:
add: Oxygen tank added to Senior Paladin's loadout.
/:cl: