### PR TITLE
Removes EXPERIMENTOR from R&D

### DIFF
--- a/code/modules/research/designs/machine_designs.dm
+++ b/code/modules/research/designs/machine_designs.dm
@@ -232,6 +232,7 @@
 	category = list("Research Machinery")
 	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE
 
+/*
 /datum/design/board/experimentor
 	name = "Machine Design (E.X.P.E.R.I-MENTOR Board)"
 	desc = "The circuit board for an E.X.P.E.R.I-MENTOR."
@@ -239,6 +240,7 @@
 	build_path = /obj/item/circuitboard/machine/experimentor
 	category = list("Research Machinery")
 	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE
+*/
 
 /datum/design/board/protolathe
 	name = "Machine Design (Protolathe Board)"

--- a/code/modules/research/designs/machine_desings/machine_designs_sci.dm
+++ b/code/modules/research/designs/machine_desings/machine_designs_sci.dm
@@ -58,6 +58,7 @@
 	category = list("Research Machinery")
 	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE
 
+/*
 /datum/design/board/experimentor
 	name = "Machine Design (E.X.P.E.R.I-MENTOR Board)"
 	desc = "The circuit board for an E.X.P.E.R.I-MENTOR."
@@ -65,6 +66,7 @@
 	build_path = /obj/item/circuitboard/machine/experimentor
 	category = list("Research Machinery")
 	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE
+*/
 
 /datum/design/board/bepis
 	name = "Machine Design (B.E.P.I.S. Board)"

--- a/code/modules/research/techweb/_techweb_node.dm
+++ b/code/modules/research/techweb/_techweb_node.dm
@@ -103,6 +103,6 @@
 	description = "NT default research technologies."
 	// Default research tech, prevents bricking
 	design_ids = list("basic_matter_bin", "basic_cell", "basic_scanning", "basic_capacitor", "basic_micro_laser", "micro_mani", "desttagger", "handlabel", "packagewrap",
-	"destructive_analyzer", "circuit_imprinter", "experimentor", "rdconsole", "bepis", "design_disk", "tech_disk", "rdserver", "rdservercontrol", "mechfab", "paystand",
+	"destructive_analyzer", "circuit_imprinter", "rdconsole", "bepis", "design_disk", "tech_disk", "rdserver", "rdservercontrol", "mechfab", "paystand",
 	"space_heater", "beaker", "large_beaker", "bucket", "xlarge_beaker", "sec_shellclip",
 	"rglass","plasteel","plastitanium","plasmaglass","plasmareinforcedglass","titaniumglass","plastitaniumglass")


### PR DESCRIPTION
## About The Pull Request

A player reported that the EXPERIMENTOR has a function that allows you to consistently duplicate items. This PR removes the ability to produce its circuitboard. The machine itself is still in the game; it just cannot be produced.

## Why It's Good For The Game

Dupe exploits are not good.

## Pre-Merge Checklist
- [x] Your Pull Request contains no breaking changes
- [x] You tested your changes locally, and they work.
- [x] There are no new Runtimes that appear.
- [x] You documented all of your changes.

<!-- Please check these accordingly. -->

## Changelog
:cl:
del: Removes the EXPERIMENTOR circuitboard design from R&D.
/:cl: