### PR TITLE
Rule 4.8: Do not rob people before the 30 minute mark

### DIFF
--- a/html/rules.html
+++ b/html/rules.html
@@ -52,8 +52,9 @@ If you have questions, submit an adminhelp (F1) and ask us!<br>
 4.3) Do not handcuff others without escalating, either via verbal warning or an emote that clearly presents your intention to handcuff them.<br>
 4.4) If a player flees from active escalation, they may be attacked immediately.<br>
 4.5) If more than two minutes pass between combat, players are required to re-escalate.<br>
-4.5) Faction members may join fights involving other faction members if and only if both participants are wearing their faction uniform, with their tags (if applicable) clearly visible.<br>
-4.6) Base raids, faction or player, require explicit permission from online staff. If you wish to raid a base you must AHELP for permission.<br>
+4.6) Faction members may join fights involving other faction members if and only if both participants are wearing their faction uniform, with their tags (if applicable) clearly visible.<br>
+4.7) Base raids, faction or player, require explicit permission from online staff. If you wish to raid a base you must AHELP for permission.<br>
+4.8) Do not rob, mug, enslave, or steal from other players until at least 30 minutes into the round. 
 4.X) If a staff member asks "Why are ghouls such good skateboarders?", answer with "Because they're super rad."<br>
 <br>
 <br>


### PR DESCRIPTION
Adds Rule 4.8: Do not rob, mug, enslave, or steal from other players until at least 30 minutes into the round.