### PR TITLE
Oasis Farmer spawn fix

### DIFF
--- a/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
@@ -5655,9 +5655,12 @@
 	},
 /area/f13/building)
 "cGU" = (
-/obj/effect/landmark/start/f13/settler,
-/turf/open/floor/wood/f13/oak,
-/area/f13/building)
+/obj/structure/simple_door/metal/fence{
+	door_type = "fence_wood";
+	icon_state = "fence_wood"
+	},
+/turf/open/indestructible/ground/outside/savannah/topleftcorner,
+/area/f13/wasteland)
 "cGV" = (
 /obj/structure/table,
 /obj/item/trash/f13/electronic/toaster,
@@ -11175,10 +11178,8 @@
 	},
 /area/f13/village)
 "fgy" = (
-/obj/effect/landmark/start/f13/settler,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	name = "metal plating"
-	},
+/obj/effect/landmark/start/f13/farmer,
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "fgB" = (
 /obj/structure/chair/sofa/left{
@@ -13137,6 +13138,13 @@
 	icon_state = "redrustychess";
 	name = "tile"
 	},
+/area/f13/building)
+"gax" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/structure/dresser,
+/turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "gay" = (
 /obj/structure/bed/mattress/pregame,
@@ -15205,9 +15213,7 @@
 	door_type = "fence_wood";
 	icon_state = "fence_wood"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	name = "metal plating"
-	},
+/turf/open/indestructible/ground/outside/savannah,
 /area/f13/wasteland)
 "gXu" = (
 /obj/effect/decal/cleanable/blood/old,
@@ -17320,6 +17326,7 @@
 /area/f13/wasteland)
 "hQQ" = (
 /obj/structure/bed/wooden,
+/obj/item/bedsheet/brown,
 /turf/open/floor/wood,
 /area/f13/building)
 "hRb" = (
@@ -24623,6 +24630,7 @@
 	},
 /area/f13/wasteland)
 "lak" = (
+/obj/effect/landmark/start/f13/settler,
 /turf/open/floor/plasteel/stairs{
 	icon = 'icons/obj/stairs.dmi'
 	},
@@ -27814,9 +27822,11 @@
 	},
 /area/f13/building)
 "mFu" = (
-/obj/structure/dresser,
-/turf/open/floor/wood/f13/oak,
-/area/f13/building)
+/obj/effect/landmark/start/f13/settler,
+/turf/open/indestructible/ground/outside/wood{
+	icon_state = "wood"
+	},
+/area/f13/wasteland)
 "mFz" = (
 /obj/structure/toilet{
 	pixel_y = 16
@@ -28235,7 +28245,6 @@
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
 	},
-/obj/effect/landmark/start/f13/settler,
 /obj/machinery/light/small{
 	dir = 1
 	},
@@ -45794,12 +45803,11 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "vcM" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
 /obj/effect/landmark/start/f13/settler,
-/turf/open/floor/wood/f13/oak,
-/area/f13/building)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	name = "metal plating"
+	},
+/area/f13/wasteland)
 "vcY" = (
 /obj/machinery/door/airlock/wood,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
@@ -76901,7 +76909,7 @@ khy
 xYI
 kEI
 mng
-ozq
+gax
 mng
 dCV
 uqa
@@ -77652,7 +77660,7 @@ iqN
 mfD
 xGH
 mvv
-fgy
+mHj
 ydO
 ydO
 ydO
@@ -77672,7 +77680,7 @@ xYI
 xYI
 kEI
 moc
-mFu
+aRl
 nqp
 dCV
 uqa
@@ -78683,7 +78691,7 @@ lEJ
 ueA
 ydO
 ydO
-fgy
+mHj
 mvv
 mvv
 mHj
@@ -84101,7 +84109,7 @@ dCV
 dCV
 dCV
 uqa
-ptf
+uqa
 ptf
 ptf
 ptf
@@ -84357,11 +84365,11 @@ ybx
 ybx
 ybx
 ybx
+dCV
 uqa
 wDc
 fyf
 fyf
-qOV
 sYX
 rpu
 rpu
@@ -84614,11 +84622,11 @@ mtR
 mWH
 nLd
 ybx
+dCV
 uqa
-bpD
+doX
+wDc
 fyf
-qOV
-daU
 kGD
 rpu
 rCD
@@ -84871,11 +84879,11 @@ xAm
 xAm
 nWu
 ybx
+dCV
 uqa
-bpD
-qOV
-daU
 mvv
+bpD
+fyf
 sYX
 rpu
 rpu
@@ -85109,7 +85117,7 @@ ozq
 ozq
 ozq
 ozq
-vcM
+ozq
 rkt
 mHj
 ydO
@@ -85128,11 +85136,11 @@ xAm
 xAm
 nZh
 ybx
+dCV
 uqa
+mvv
 bpD
-tBN
-mvv
-mvv
+fyf
 kGD
 rpu
 chc
@@ -85359,7 +85367,7 @@ cEb
 dve
 ozq
 ejT
-vcM
+ozq
 aRl
 ozq
 mcI
@@ -85385,11 +85393,11 @@ xAm
 xAm
 oei
 ybx
+dCV
 uqa
-bpD
-nlO
-xGH
 mvv
+bpD
+fyf
 sYX
 rpu
 rpu
@@ -85642,11 +85650,11 @@ xUO
 xUO
 wnn
 ybx
+dCV
 uqa
+mvv
 bpD
 fyf
-tBN
-mvv
 viK
 voR
 rpu
@@ -85899,11 +85907,11 @@ xUO
 xUO
 ofK
 ybx
+dCV
 uqa
+mvv
 bpD
 fyf
-tBN
-mvv
 sYX
 sYX
 sDp
@@ -86156,11 +86164,11 @@ xUO
 xUO
 wnn
 ybx
+dCV
 uqa
+mvv
 bpD
 fyf
-tBN
-mvv
 sYX
 mtb
 rpu
@@ -86413,11 +86421,11 @@ xUO
 xUO
 xUO
 uLh
+dCV
 uqa
+mvv
 doX
 wDc
-tBN
-mvv
 kGD
 rpu
 rpu
@@ -86670,11 +86678,11 @@ mtV
 mXF
 ohp
 mvV
+dCV
 uqa
 uqa
+mvv
 bpD
-nlO
-xGH
 sYX
 vUF
 aIl
@@ -86896,7 +86904,7 @@ uqa
 dCV
 bZi
 uqa
-cGU
+aRl
 ozq
 nJU
 aRl
@@ -86928,10 +86936,10 @@ ybx
 ybx
 ybx
 ybx
+dCV
 uqa
+mvv
 bpD
-fyf
-nlO
 sYX
 sYX
 kGD
@@ -87185,10 +87193,10 @@ nbI
 oiw
 oqA
 ybx
+dCV
 uqa
+mvv
 bpD
-fyf
-fyf
 ilu
 trd
 xKx
@@ -87442,10 +87450,10 @@ xiy
 xiy
 xiy
 ybx
+dCV
 uqa
+mvv
 bpD
-fyf
-fyf
 tVV
 lae
 esP
@@ -87699,10 +87707,10 @@ xiy
 viV
 xiy
 ybx
+dCV
 uqa
-doX
-wDc
-fyf
+mvv
+bpD
 wIW
 wIW
 wIW
@@ -87956,10 +87964,10 @@ ncF
 oli
 osB
 ybx
+dCV
 uqa
-uqa
+mvv
 bpD
-fyf
 wIW
 rWS
 lTk
@@ -88215,8 +88223,8 @@ ybx
 ybx
 dCV
 uqa
+mvv
 bpD
-fyf
 wIW
 gvW
 rpu
@@ -88472,8 +88480,8 @@ uqa
 uqa
 dCV
 uqa
+mvv
 bpD
-fyf
 wIW
 rWS
 rpu
@@ -88729,8 +88737,8 @@ osQ
 uqa
 dCV
 uqa
+mvv
 bpD
-fyf
 wIW
 djI
 rpu
@@ -88986,8 +88994,8 @@ otI
 uqa
 dCV
 uqa
+mvv
 bpD
-fyf
 wIW
 qZJ
 rpu
@@ -89215,7 +89223,7 @@ gXt
 dZi
 mvv
 mvv
-mvv
+fgy
 mvv
 mvv
 puV
@@ -89233,7 +89241,7 @@ ydO
 ydO
 ydO
 ydO
-mHj
+vcM
 uqa
 aRl
 aRl
@@ -89243,8 +89251,8 @@ xyX
 uqa
 dCV
 uqa
+mvv
 bpD
-fyf
 wIW
 wIW
 wIW
@@ -89468,11 +89476,11 @@ fDi
 fZe
 fCO
 fDi
-gXt
+cGU
 ebx
 mvv
 mvv
-mvv
+fgy
 mvv
 mvv
 puV
@@ -89486,7 +89494,7 @@ uqa
 why
 uqa
 uqa
-ydO
+mFu
 ydO
 ydO
 ydO
@@ -89500,8 +89508,8 @@ uqa
 uqa
 dCV
 uqa
+mvv
 bpD
-fyf
 fyf
 fyf
 fyf
@@ -89757,8 +89765,8 @@ hEp
 uqa
 dCV
 uqa
+mvv
 bpD
-fyf
 fyf
 fyf
 fyf
@@ -90014,9 +90022,9 @@ lUZ
 uqa
 dCV
 uqa
+mvv
 doX
 wDc
-fyf
 jcp
 fyf
 uey
@@ -90272,8 +90280,8 @@ uqa
 dCV
 uqa
 uqa
+mvv
 bpD
-fyf
 fyf
 fyf
 fyf
@@ -90529,8 +90537,8 @@ dCV
 dCV
 dCV
 uqa
+mvv
 bpD
-fyf
 fyf
 fyf
 fyf
@@ -90786,8 +90794,8 @@ uqa
 uqa
 dCV
 uqa
+mvv
 bpD
-fyf
 fyf
 fyf
 fyf
@@ -91043,8 +91051,8 @@ ouu
 uqa
 dCV
 uqa
+mvv
 bpD
-fyf
 fyf
 sVO
 wim
@@ -91300,8 +91308,8 @@ lUZ
 uqa
 dCV
 uqa
-doX
-wDc
+mvv
+bpD
 fyf
 xHc
 daU

--- a/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
@@ -14284,12 +14284,6 @@
 	icon_state = "housewood2-broken"
 	},
 /area/f13/ncr)
-"gxW" = (
-/obj/item/flag/yuma,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticalrightborderright0"
-	},
-/area/f13/wasteland)
 "gxZ" = (
 /obj/machinery/button/door{
 	id = "hospitalgarage1";
@@ -18775,14 +18769,6 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/village)
-"izI" = (
-/obj/item/flag/yuma{
-	icon_state = "cornflag2"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	name = "metal plating"
-	},
-/area/f13/wasteland)
 "izR" = (
 /obj/structure/chair,
 /obj/effect/decal/remains/human,
@@ -27266,12 +27252,6 @@
 /obj/machinery/chem_heater,
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/village)
-"moy" = (
-/obj/item/flag/yuma,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticalleftborderleft0"
-	},
-/area/f13/wasteland)
 "moz" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -77148,7 +77128,7 @@ ydO
 ydO
 ydO
 ydO
-izI
+mHj
 ydO
 ydO
 mHj
@@ -82788,14 +82768,14 @@ mEL
 wKo
 gkv
 ybI
-moy
+ybI
 dCV
 dCV
 ekB
 ekB
 ekB
 jfj
-izI
+mHj
 mHj
 mHj
 yes
@@ -82822,7 +82802,7 @@ lMA
 lMA
 dCV
 dCV
-moy
+ybI
 ybI
 ybI
 ybI
@@ -83816,14 +83796,14 @@ hWk
 rkr
 geM
 ees
-gxW
+ees
 dCV
 dCV
 dCV
 dCV
 dCV
 dCV
-izI
+mHj
 mHj
 mHj
 mHj
@@ -83850,7 +83830,7 @@ dCV
 dCV
 dCV
 dCV
-gxW
+ees
 ees
 kKo
 ees

--- a/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
@@ -9893,11 +9893,8 @@
 /turf/open/floor/carpet,
 /area/f13/building)
 "eHj" = (
-/obj/machinery/door/poddoor/shutters{
-	id = "prospectordoor"
-	},
 /obj/machinery/door/airlock/wood{
-	req_one_access_txt = "48"
+	req_one_access_txt = "25"
 	},
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"

--- a/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
@@ -14284,6 +14284,17 @@
 	icon_state = "housewood2-broken"
 	},
 /area/f13/ncr)
+"gxW" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/structure/simple_door/wood{
+	name = "Town Hall"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	name = "metal plating"
+	},
+/area/f13/building)
 "gxZ" = (
 /obj/machinery/button/door{
 	id = "hospitalgarage1";
@@ -76615,7 +76626,7 @@ doX
 cWG
 daU
 gCh
-llq
+gxW
 llq
 nKA
 sYX

--- a/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
@@ -18780,6 +18780,15 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/village)
+"izI" = (
+/obj/machinery/vending/clothing,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	name = "metal plating"
+	},
+/area/f13/wasteland)
 "izR" = (
 /obj/structure/chair,
 /obj/effect/decal/remains/human,
@@ -91539,7 +91548,7 @@ tBN
 uqa
 dCV
 dCV
-nsP
+izI
 ydO
 mHj
 mHj

--- a/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
@@ -9893,8 +9893,11 @@
 /turf/open/floor/carpet,
 /area/f13/building)
 "eHj" = (
+/obj/machinery/door/poddoor/shutters{
+	id = "prospectordoor"
+	},
 /obj/machinery/door/airlock/wood{
-	req_one_access_txt = "25"
+	req_one_access_txt = "48"
 	},
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"

--- a/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
@@ -4952,21 +4952,10 @@
 	},
 /area/f13/den)
 "daK" = (
-/obj/structure/rack,
-/obj/item/clothing/under/f13/recon,
-/obj/item/clothing/under/f13/recon,
-/obj/item/clothing/under/f13/recon,
-/obj/item/clothing/under/f13/recon,
-/obj/item/clothing/under/f13/recon,
-/obj/item/clothing/under/f13/recon,
-/obj/item/clothing/under/f13/recon,
-/obj/item/clothing/under/f13/recon,
-/obj/item/clothing/under/f13/recon,
-/obj/item/clothing/under/f13/recon,
 /obj/effect/turf_decal/stripes/red/line{
-	dir = 6;
-	icon_state = "warningline_red"
+	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
 	icon_state = "reddirtyfull"
@@ -4984,141 +4973,18 @@
 /turf/open/floor/wood/f13/old,
 /area/f13/den)
 "dbr" = (
-/obj/structure/rack,
-/obj/item/storage/belt/military/army,
-/obj/item/storage/belt/military/army,
-/obj/item/storage/belt/military/army,
-/obj/item/storage/belt/military/army,
-/obj/item/storage/belt/military/army,
-/obj/item/clothing/mask/gas/sechailer,
-/obj/item/clothing/mask/gas/sechailer,
-/obj/item/clothing/mask/gas/sechailer,
-/obj/item/clothing/mask/gas/sechailer,
-/obj/item/clothing/mask/gas/sechailer,
-/obj/item/clothing/mask/gas/sechailer,
-/obj/item/clothing/shoes/combat/swat{
-	pixel_x = 7;
-	pixel_y = -9
+/obj/item/target,
+/obj/item/target,
+/obj/item/target,
+/obj/item/target,
+/obj/item/target,
+/obj/item/target,
+/obj/item/target,
+/obj/item/target,
+/obj/item/target,
+/obj/structure/closet/crate{
+	anchored = 1
 	},
-/obj/item/clothing/shoes/combat/swat{
-	pixel_x = 7;
-	pixel_y = -9
-	},
-/obj/item/clothing/shoes/combat/swat{
-	pixel_x = 7;
-	pixel_y = -9
-	},
-/obj/item/clothing/shoes/combat/swat{
-	pixel_x = 7;
-	pixel_y = -9
-	},
-/obj/item/clothing/shoes/combat/swat{
-	pixel_x = 7;
-	pixel_y = -9
-	},
-/obj/item/storage/belt/military{
-	pixel_x = -7;
-	pixel_y = -9
-	},
-/obj/item/storage/belt/military{
-	pixel_x = -7;
-	pixel_y = -9
-	},
-/obj/item/storage/belt/military{
-	pixel_x = -7;
-	pixel_y = -9
-	},
-/obj/item/storage/belt/military{
-	pixel_x = -7;
-	pixel_y = -9
-	},
-/obj/item/storage/belt/military{
-	pixel_x = -7;
-	pixel_y = -9
-	},
-/obj/item/clothing/mask/gas/sechailer/swat{
-	pixel_x = 8;
-	pixel_y = 8
-	},
-/obj/item/clothing/mask/gas/sechailer/swat{
-	pixel_x = 8;
-	pixel_y = 8
-	},
-/obj/item/clothing/mask/gas/sechailer/swat{
-	pixel_x = 8;
-	pixel_y = 8
-	},
-/obj/item/clothing/mask/gas/sechailer/swat{
-	pixel_x = 8;
-	pixel_y = 8
-	},
-/obj/item/clothing/mask/gas/sechailer/swat{
-	pixel_x = 8;
-	pixel_y = 8
-	},
-/obj/item/clothing/head/helmet/f13/combat/brotherhood/initiate{
-	pixel_x = -9;
-	pixel_y = 10
-	},
-/obj/item/clothing/head/helmet/f13/combat/brotherhood/initiate{
-	pixel_x = -9;
-	pixel_y = 10
-	},
-/obj/item/clothing/head/helmet/f13/combat/brotherhood/initiate{
-	pixel_x = -9;
-	pixel_y = 10
-	},
-/obj/item/clothing/head/helmet/f13/combat/brotherhood/initiate{
-	pixel_x = -9;
-	pixel_y = 10
-	},
-/obj/item/clothing/head/helmet/f13/combat/brotherhood/initiate{
-	pixel_x = -9;
-	pixel_y = 10
-	},
-/obj/item/clothing/head/helmet/f13/combat/brotherhood/initiate{
-	pixel_x = -9;
-	pixel_y = 10
-	},
-/obj/item/clothing/suit/armor/f13/combat/brotherhood/initiate{
-	pixel_x = -9;
-	pixel_y = 6
-	},
-/obj/item/clothing/suit/armor/f13/combat/brotherhood/initiate{
-	pixel_x = -9;
-	pixel_y = 6
-	},
-/obj/item/clothing/suit/armor/f13/combat/brotherhood/initiate{
-	pixel_x = -9;
-	pixel_y = 6
-	},
-/obj/item/clothing/suit/armor/f13/combat/brotherhood/initiate{
-	pixel_x = -9;
-	pixel_y = 6
-	},
-/obj/item/clothing/suit/armor/f13/combat/brotherhood/initiate{
-	pixel_x = -9;
-	pixel_y = 6
-	},
-/obj/item/clothing/mask/gas/explorer{
-	pixel_y = 11
-	},
-/obj/item/clothing/mask/gas/explorer{
-	pixel_y = 11
-	},
-/obj/item/clothing/mask/gas/explorer{
-	pixel_y = 11
-	},
-/obj/item/clothing/mask/gas/explorer{
-	pixel_y = 11
-	},
-/obj/item/clothing/mask/gas/explorer{
-	pixel_y = 11
-	},
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
 	icon_state = "reddirtyfull"
 	},
@@ -5289,12 +5155,11 @@
 	},
 /area/f13/den)
 "dhi" = (
-/obj/structure/rack,
-/obj/item/clothing/suit/bomb_suit/security,
-/obj/item/clothing/head/bomb_hood/security,
+/obj/machinery/light/small{
+	dir = 4
+	},
 /obj/effect/turf_decal/stripes/red/line{
-	dir = 10;
-	icon_state = "warningline_red"
+	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
@@ -6338,6 +6203,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/rack,
 /turf/open/floor/f13{
 	icon_state = "reddirtyfull"
 	},
@@ -6360,18 +6226,6 @@
 	icon_state = "tealwhdirty"
 	},
 /area/f13/den)
-"dJD" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/brotherhood/armory)
 "dJF" = (
 /obj/item/instrument/accordion,
 /obj/structure/rack,
@@ -9033,11 +8887,14 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/brotherhood/armory)
 "flq" = (
-/obj/structure/rack,
 /obj/effect/turf_decal/stripes/red/line{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/vending/clothing/bos{
+	density = 0;
+	pixel_x = 32
+	},
 /turf/open/floor/f13{
 	icon_state = "reddirtyfull"
 	},
@@ -10252,9 +10109,6 @@
 /area/f13/den)
 "fTM" = (
 /obj/structure/rack,
-/obj/machinery/light/small{
-	dir = 4
-	},
 /obj/effect/turf_decal/stripes/red/line{
 	dir = 4
 	},
@@ -10954,6 +10808,7 @@
 /obj/effect/turf_decal/stripes/red/line{
 	dir = 8
 	},
+/obj/structure/rack,
 /turf/open/floor/f13{
 	icon_state = "reddirtyfull"
 	},
@@ -11019,6 +10874,7 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/rack,
 /turf/open/floor/f13{
 	icon_state = "reddirtyfull"
 	},
@@ -12118,12 +11974,9 @@
 /area/f13/brotherhood/armory)
 "gTE" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/rack,
-/obj/item/twohanded/sledgehammer/supersledge,
 /obj/effect/turf_decal/stripes/red/line{
-	dir = 5
+	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
 	icon_state = "reddirtyfull"
 	},
@@ -12139,33 +11992,17 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/operations)
 "gUf" = (
-/obj/structure/rack,
-/obj/item/storage/belt/utility/full,
-/obj/item/storage/belt/utility/full,
-/obj/item/storage/belt/utility/full,
-/obj/item/storage/belt/utility/full,
-/obj/effect/turf_decal/stripes/red/line,
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
 	icon_state = "reddirtyfull"
 	},
 /area/f13/brotherhood/armory)
 "gUm" = (
-/obj/structure/rack,
-/obj/item/pda,
-/obj/item/pda,
-/obj/item/pda,
-/obj/item/pda,
-/obj/item/pda,
-/obj/item/pda,
-/obj/item/pda,
-/obj/item/pda,
-/obj/item/pda,
-/obj/item/pda,
-/obj/item/book/granter/trait/pa_wear,
 /obj/effect/turf_decal/stripes/red/line{
-	dir = 9;
-	icon_state = "warningline_red"
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 4
 	},
 /turf/open/floor/f13{
 	icon_state = "reddirtyfull"
@@ -12639,6 +12476,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
 "hmP" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/crate/bin,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
 	icon_state = "reddirtyfull"
 	},
@@ -12998,9 +12838,6 @@
 	name = "Armory Camera";
 	network = list("BoS");
 	pixel_x = -1
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 32
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
@@ -13923,10 +13760,10 @@
 	},
 /area/f13/brotherhood/mining)
 "inm" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 1;
-	icon_state = "warningline_red"
+/obj/structure/simple_door/bunker{
+	name = "Firing Range";
+	req_access = 120;
+	req_access_txt = "120"
 	},
 /turf/open/floor/f13{
 	icon_state = "reddirtyfull"
@@ -13993,14 +13830,11 @@
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/archives)
 "iqY" = (
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 1;
-	icon_state = "warningline_red"
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 32
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/brotherhood/armory)
 "iro" = (
 /obj/structure/decoration/vent,
@@ -14033,18 +13867,8 @@
 /turf/open/floor/wood/f13/oak,
 /area/f13/den)
 "irU" = (
-/obj/item/toy/plush/nukeplushie{
-	desc = "A stuffed toy that resembles a Chinese spy/ The tag claims operatives to be purely fictitious and not stealing your armory.";
-	name = "Knight-Captain Aryom";
-	pixel_x = 9
-	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
+/turf/closed/wall/r_wall,
 /area/f13/brotherhood/armory)
 "ise" = (
 /turf/open/floor/f13{
@@ -14069,10 +13893,21 @@
 /area/f13/brotherhood/operations)
 "isV" = (
 /obj/structure/rack,
-/obj/item/pda{
-	icon_state = "pda-warden";
-	name = "Armory Warden PDA"
+/obj/item/clothing/under/f13/recon,
+/obj/item/clothing/under/f13/recon,
+/obj/item/clothing/under/f13/recon,
+/obj/item/clothing/under/f13/recon,
+/obj/item/clothing/under/f13/recon,
+/obj/item/clothing/under/f13/recon,
+/obj/item/clothing/under/f13/recon,
+/obj/item/clothing/under/f13/recon,
+/obj/item/clothing/under/f13/recon,
+/obj/item/clothing/under/f13/recon,
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 6;
+	icon_state = "warningline_red"
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
 	icon_state = "reddirtyfull"
 	},
@@ -14274,6 +14109,15 @@
 /obj/item/wallframe/camera,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
+"iAL" = (
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 1;
+	icon_state = "warningline_red"
+	},
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/brotherhood/armory)
 "iAR" = (
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/offices1st)
@@ -14496,13 +14340,11 @@
 /turf/open/floor/wood/wood_tiled,
 /area/f13/followers)
 "iMP" = (
-/obj/machinery/button/door{
-	id = "bosarmoryacc";
-	normaldoorcontrol = 1;
-	pixel_x = -23;
-	specialfunctions = 4
-	},
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 1;
+	icon_state = "warningline_red"
+	},
 /turf/open/floor/f13{
 	icon_state = "reddirtyfull"
 	},
@@ -14871,23 +14713,6 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/followers)
-"iZH" = (
-/obj/item/target,
-/obj/item/target,
-/obj/item/target,
-/obj/item/target,
-/obj/item/target,
-/obj/item/target,
-/obj/item/target,
-/obj/item/target,
-/obj/item/target,
-/obj/structure/closet/crate{
-	anchored = 1
-	},
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/brotherhood/armory)
 "iZM" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /mob/living/simple_animal/hostile/securitron/nsb,
@@ -14971,9 +14796,7 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker)
 "jdS" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/crate/bin,
-/obj/effect/decal/cleanable/dirt,
+/obj/structure/window/fulltile/store,
 /turf/open/floor/f13{
 	icon_state = "reddirtyfull"
 	},
@@ -15352,21 +15175,9 @@
 /turf/open/water,
 /area/f13/brotherhood/archives)
 "jtx" = (
-/obj/structure/closet/crate/secure/weapon{
-	anchored = 1
-	},
-/obj/item/stock_parts/cell/ammo/ec,
-/obj/item/stock_parts/cell/ammo/ec,
-/obj/item/stock_parts/cell/ammo/ec,
-/obj/item/stock_parts/cell/ammo/ec,
-/obj/item/stock_parts/cell/ammo/ec,
-/obj/item/stock_parts/cell/ammo/ec,
-/obj/item/stock_parts/cell/ammo/ec,
-/obj/item/stock_parts/cell/ammo/ec,
-/obj/item/stock_parts/cell/ammo/ec,
-/obj/item/stock_parts/cell/ammo/ec,
-/obj/item/stock_parts/cell/ammo/ec,
-/obj/item/stock_parts/cell/ammo/ec,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/rack,
+/obj/item/twohanded/sledgehammer/supersledge,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/bot_red,
 /turf/open/floor/f13{
@@ -15416,6 +15227,10 @@
 /obj/structure/rack,
 /obj/item/shield/riot/bullet_proof,
 /obj/item/shield/riot/bullet_proof,
+/obj/item/pda{
+	icon_state = "pda-warden";
+	name = "Armory Warden PDA"
+	},
 /turf/open/floor/f13{
 	icon_state = "reddirtyfull"
 	},
@@ -18107,6 +17922,16 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
+"lzF" = (
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 1;
+	icon_state = "warningline_red"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/brotherhood/armory)
 "lAw" = (
 /obj/structure/girder/reinforced,
 /turf/open/indestructible/ground/inside/mountain,
@@ -19485,10 +19310,9 @@
 	},
 /area/f13/clinic)
 "mFZ" = (
-/obj/structure/window/fulltile/store,
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/crate/bin,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/brotherhood/armory)
 "mGK" = (
 /obj/structure/fence/handrail{
@@ -19538,6 +19362,31 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/bunker)
+"mIx" = (
+/obj/structure/closet/crate/secure/weapon{
+	anchored = 1
+	},
+/obj/item/stock_parts/cell/ammo/ecp,
+/obj/item/stock_parts/cell/ammo/ecp,
+/obj/item/stock_parts/cell/ammo/ecp,
+/obj/item/stock_parts/cell/ammo/ecp,
+/obj/item/stock_parts/cell/ammo/ecp,
+/obj/item/stock_parts/cell/ammo/ecp,
+/obj/item/stock_parts/cell/ammo/ecp,
+/obj/item/stock_parts/cell/ammo/ecp,
+/obj/item/stock_parts/cell/ammo/ecp,
+/obj/item/stock_parts/cell/ammo/ecp,
+/obj/item/stock_parts/cell/ammo/ecp,
+/obj/item/stock_parts/cell/ammo/ecp,
+/obj/item/stock_parts/cell/ammo/ecp,
+/obj/item/stock_parts/cell/ammo/ecp,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small,
+/obj/effect/turf_decal/stripes/red/line,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/brotherhood/armory)
 "mII" = (
 /obj/effect/turf_decal/delivery/white,
 /obj/machinery/door/poddoor/shutters{
@@ -19609,25 +19458,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/operations)
 "mLP" = (
-/obj/structure/closet/crate/secure/weapon{
-	anchored = 1
-	},
-/obj/item/stock_parts/cell/ammo/ecp,
-/obj/item/stock_parts/cell/ammo/ecp,
-/obj/item/stock_parts/cell/ammo/ecp,
-/obj/item/stock_parts/cell/ammo/ecp,
-/obj/item/stock_parts/cell/ammo/ecp,
-/obj/item/stock_parts/cell/ammo/ecp,
-/obj/item/stock_parts/cell/ammo/ecp,
-/obj/item/stock_parts/cell/ammo/ecp,
-/obj/item/stock_parts/cell/ammo/ecp,
-/obj/item/stock_parts/cell/ammo/ecp,
-/obj/item/stock_parts/cell/ammo/ecp,
-/obj/item/stock_parts/cell/ammo/ecp,
-/obj/item/stock_parts/cell/ammo/ecp,
-/obj/item/stock_parts/cell/ammo/ecp,
+/obj/structure/rack,
+/obj/item/storage/belt/utility/full,
+/obj/item/storage/belt/utility/full,
+/obj/item/storage/belt/utility/full,
+/obj/item/storage/belt/utility/full,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small,
 /obj/effect/turf_decal/bot_red,
 /turf/open/floor/f13{
 	icon_state = "reddirtyfull"
@@ -19654,25 +19490,18 @@
 /turf/open/floor/plasteel/f13/vault_floor/red/white,
 /area/f13/brotherhood/reactor)
 "mMk" = (
-/obj/structure/closet/crate/secure/weapon{
-	anchored = 1
-	},
-/obj/item/stock_parts/cell/ammo/mfc,
-/obj/item/stock_parts/cell/ammo/mfc,
-/obj/item/stock_parts/cell/ammo/mfc,
-/obj/item/stock_parts/cell/ammo/mfc,
-/obj/item/stock_parts/cell/ammo/mfc,
-/obj/item/stock_parts/cell/ammo/mfc,
-/obj/item/stock_parts/cell/ammo/mfc,
-/obj/item/stock_parts/cell/ammo/mfc,
-/obj/item/stock_parts/cell/ammo/mfc,
-/obj/item/stock_parts/cell/ammo/mfc,
-/obj/item/stock_parts/cell/ammo/mfc,
-/obj/item/stock_parts/cell/ammo/mfc,
-/obj/item/stock_parts/cell/ammo/mfc,
-/obj/item/stock_parts/cell/ammo/mfc,
-/obj/item/stock_parts/cell/ammo/mfc,
-/obj/effect/decal/cleanable/dirt,
+/obj/structure/rack,
+/obj/item/pda,
+/obj/item/pda,
+/obj/item/pda,
+/obj/item/pda,
+/obj/item/pda,
+/obj/item/pda,
+/obj/item/pda,
+/obj/item/pda,
+/obj/item/pda,
+/obj/item/pda,
+/obj/item/book/granter/trait/pa_wear,
 /obj/effect/turf_decal/bot_red,
 /turf/open/floor/f13{
 	icon_state = "reddirtyfull"
@@ -20291,11 +20120,141 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/operations)
 "nek" = (
-/obj/structure/simple_door/bunker{
-	name = "Firing Range";
-	req_access = 120;
-	req_access_txt = "120"
+/obj/structure/rack,
+/obj/item/storage/belt/military/army,
+/obj/item/storage/belt/military/army,
+/obj/item/storage/belt/military/army,
+/obj/item/storage/belt/military/army,
+/obj/item/storage/belt/military/army,
+/obj/item/clothing/mask/gas/sechailer,
+/obj/item/clothing/mask/gas/sechailer,
+/obj/item/clothing/mask/gas/sechailer,
+/obj/item/clothing/mask/gas/sechailer,
+/obj/item/clothing/mask/gas/sechailer,
+/obj/item/clothing/mask/gas/sechailer,
+/obj/item/clothing/shoes/combat/swat{
+	pixel_x = 7;
+	pixel_y = -9
 	},
+/obj/item/clothing/shoes/combat/swat{
+	pixel_x = 7;
+	pixel_y = -9
+	},
+/obj/item/clothing/shoes/combat/swat{
+	pixel_x = 7;
+	pixel_y = -9
+	},
+/obj/item/clothing/shoes/combat/swat{
+	pixel_x = 7;
+	pixel_y = -9
+	},
+/obj/item/clothing/shoes/combat/swat{
+	pixel_x = 7;
+	pixel_y = -9
+	},
+/obj/item/storage/belt/military{
+	pixel_x = -7;
+	pixel_y = -9
+	},
+/obj/item/storage/belt/military{
+	pixel_x = -7;
+	pixel_y = -9
+	},
+/obj/item/storage/belt/military{
+	pixel_x = -7;
+	pixel_y = -9
+	},
+/obj/item/storage/belt/military{
+	pixel_x = -7;
+	pixel_y = -9
+	},
+/obj/item/storage/belt/military{
+	pixel_x = -7;
+	pixel_y = -9
+	},
+/obj/item/clothing/mask/gas/sechailer/swat{
+	pixel_x = 8;
+	pixel_y = 8
+	},
+/obj/item/clothing/mask/gas/sechailer/swat{
+	pixel_x = 8;
+	pixel_y = 8
+	},
+/obj/item/clothing/mask/gas/sechailer/swat{
+	pixel_x = 8;
+	pixel_y = 8
+	},
+/obj/item/clothing/mask/gas/sechailer/swat{
+	pixel_x = 8;
+	pixel_y = 8
+	},
+/obj/item/clothing/mask/gas/sechailer/swat{
+	pixel_x = 8;
+	pixel_y = 8
+	},
+/obj/item/clothing/head/helmet/f13/combat/brotherhood/initiate{
+	pixel_x = -9;
+	pixel_y = 10
+	},
+/obj/item/clothing/head/helmet/f13/combat/brotherhood/initiate{
+	pixel_x = -9;
+	pixel_y = 10
+	},
+/obj/item/clothing/head/helmet/f13/combat/brotherhood/initiate{
+	pixel_x = -9;
+	pixel_y = 10
+	},
+/obj/item/clothing/head/helmet/f13/combat/brotherhood/initiate{
+	pixel_x = -9;
+	pixel_y = 10
+	},
+/obj/item/clothing/head/helmet/f13/combat/brotherhood/initiate{
+	pixel_x = -9;
+	pixel_y = 10
+	},
+/obj/item/clothing/head/helmet/f13/combat/brotherhood/initiate{
+	pixel_x = -9;
+	pixel_y = 10
+	},
+/obj/item/clothing/suit/armor/f13/combat/brotherhood/initiate{
+	pixel_x = -9;
+	pixel_y = 6
+	},
+/obj/item/clothing/suit/armor/f13/combat/brotherhood/initiate{
+	pixel_x = -9;
+	pixel_y = 6
+	},
+/obj/item/clothing/suit/armor/f13/combat/brotherhood/initiate{
+	pixel_x = -9;
+	pixel_y = 6
+	},
+/obj/item/clothing/suit/armor/f13/combat/brotherhood/initiate{
+	pixel_x = -9;
+	pixel_y = 6
+	},
+/obj/item/clothing/suit/armor/f13/combat/brotherhood/initiate{
+	pixel_x = -9;
+	pixel_y = 6
+	},
+/obj/item/clothing/mask/gas/explorer{
+	pixel_y = 11
+	},
+/obj/item/clothing/mask/gas/explorer{
+	pixel_y = 11
+	},
+/obj/item/clothing/mask/gas/explorer{
+	pixel_y = 11
+	},
+/obj/item/clothing/mask/gas/explorer{
+	pixel_y = 11
+	},
+/obj/item/clothing/mask/gas/explorer{
+	pixel_y = 11
+	},
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
 	icon_state = "reddirtyfull"
 	},
@@ -28362,6 +28321,18 @@
 /obj/machinery/light/small,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
+"sEt" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/toy/plush/nukeplushie{
+	desc = "A stuffed toy that resembles a Chinese spy/ The tag claims operatives to be purely fictitious and not stealing your armory.";
+	name = "Knight-Captain Aryom";
+	pixel_x = 9
+	},
+/obj/machinery/light/small,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/brotherhood/armory)
 "sEw" = (
 /obj/structure/ladder/unbreakable{
 	height = 1;
@@ -28512,6 +28483,34 @@
 	},
 /turf/open/floor/wood/f13/old,
 /area/f13/caves)
+"sNW" = (
+/obj/structure/closet/crate/secure/weapon{
+	anchored = 1
+	},
+/obj/item/stock_parts/cell/ammo/mfc,
+/obj/item/stock_parts/cell/ammo/mfc,
+/obj/item/stock_parts/cell/ammo/mfc,
+/obj/item/stock_parts/cell/ammo/mfc,
+/obj/item/stock_parts/cell/ammo/mfc,
+/obj/item/stock_parts/cell/ammo/mfc,
+/obj/item/stock_parts/cell/ammo/mfc,
+/obj/item/stock_parts/cell/ammo/mfc,
+/obj/item/stock_parts/cell/ammo/mfc,
+/obj/item/stock_parts/cell/ammo/mfc,
+/obj/item/stock_parts/cell/ammo/mfc,
+/obj/item/stock_parts/cell/ammo/mfc,
+/obj/item/stock_parts/cell/ammo/mfc,
+/obj/item/stock_parts/cell/ammo/mfc,
+/obj/item/stock_parts/cell/ammo/mfc,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 9;
+	icon_state = "warningline_red"
+	},
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/brotherhood/armory)
 "sNX" = (
 /mob/living/simple_animal/hostile/radroach,
 /turf/open/indestructible/ground/inside/mountain,
@@ -29288,6 +29287,12 @@
 	},
 /turf/open/floor/carpet,
 /area/f13/ncr)
+"tvd" = (
+/obj/structure/rack,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/brotherhood/armory)
 "tvw" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -29623,8 +29628,28 @@
 /turf/open/floor/wood/f13/stage_l,
 /area/f13/ncr)
 "tHk" = (
+/obj/structure/closet/crate/secure/weapon{
+	anchored = 1
+	},
+/obj/item/stock_parts/cell/ammo/ec,
+/obj/item/stock_parts/cell/ammo/ec,
+/obj/item/stock_parts/cell/ammo/ec,
+/obj/item/stock_parts/cell/ammo/ec,
+/obj/item/stock_parts/cell/ammo/ec,
+/obj/item/stock_parts/cell/ammo/ec,
+/obj/item/stock_parts/cell/ammo/ec,
+/obj/item/stock_parts/cell/ammo/ec,
+/obj/item/stock_parts/cell/ammo/ec,
+/obj/item/stock_parts/cell/ammo/ec,
+/obj/item/stock_parts/cell/ammo/ec,
+/obj/item/stock_parts/cell/ammo/ec,
 /obj/effect/decal/cleanable/dirt,
-/turf/closed/wall/r_wall,
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 5
+	},
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
 /area/f13/brotherhood/armory)
 "tHD" = (
 /obj/structure/table/wood,
@@ -34103,6 +34128,13 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/bunker)
+"xkq" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/rack,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/brotherhood/armory)
 "xkr" = (
 /obj/machinery/door/airlock/grunge{
 	name = "Elder's Office";
@@ -34466,10 +34498,14 @@
 /turf/closed/wall/f13/ruins,
 /area/f13/caves)
 "xwn" = (
+/obj/structure/rack,
+/obj/item/clothing/suit/bomb_suit/security,
+/obj/item/clothing/head/bomb_hood/security,
 /obj/effect/turf_decal/stripes/red/line{
-	dir = 1;
+	dir = 10;
 	icon_state = "warningline_red"
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
 	icon_state = "reddirtyfull"
 	},
@@ -99160,8 +99196,8 @@ bvr
 gCD
 bTP
 fpv
-llQ
-iZH
+dbr
+jdS
 mFZ
 cZm
 dID
@@ -99171,7 +99207,7 @@ fQU
 goR
 gTD
 jKY
-inm
+jKY
 iMP
 jtx
 wKL
@@ -99418,8 +99454,7 @@ gCD
 bVc
 pvq
 llQ
-llQ
-nek
+inm
 jKY
 jKY
 jKY
@@ -99428,8 +99463,9 @@ jKY
 jKY
 jKY
 jKY
-xwn
-llQ
+jKY
+jKY
+iAL
 mLP
 wKL
 wKL
@@ -99675,8 +99711,8 @@ gCD
 bVc
 pvq
 llQ
-llQ
-nek
+inm
+jKY
 jKY
 jKY
 jKY
@@ -99686,7 +99722,7 @@ jKY
 jKY
 hBC
 iqY
-llQ
+lzF
 mMk
 dMW
 nXm
@@ -99931,18 +99967,18 @@ gCD
 gCD
 bVc
 pvq
-llQ
-hmP
-mFZ
+gUf
+jdS
+isV
 daK
 dIU
 ezG
-ezG
+gTE
 fSK
 gpZ
 gTE
 tHk
-mMr
+irU
 iNo
 mMr
 dMW
@@ -100190,18 +100226,18 @@ gCD
 eRN
 hmP
 jdS
-mFZ
-dbr
+nek
 llQ
+xkq
+xkq
 llQ
+tvd
+xkq
 llQ
-hmP
-llQ
-gUf
-tHk
+mIx
 irU
 llQ
-llQ
+sEt
 gkr
 kxR
 wfY
@@ -100447,16 +100483,16 @@ dMW
 dMW
 dMW
 dMW
-dMW
+xwn
 dhi
-dJD
+gsd
 eEL
 flq
 fTM
 gsd
 gUm
+sNW
 dMW
-isV
 iOt
 juq
 dMW
@@ -100703,7 +100739,7 @@ eLE
 eLE
 eLE
 eLE
-eLE
+tEj
 tEj
 tEj
 tEj

--- a/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
@@ -21964,9 +21964,8 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/item/clothing/glasses/hud/health/night,
-/obj/item/clothing/glasses/hud/health/night,
 /obj/item/pda,
+/obj/item/clothing/glasses/hud/health/f13,
 /turf/open/floor/f13{
 	icon_state = "bluerustysolid"
 	},
@@ -35068,7 +35067,8 @@
 /area/f13/bunker)
 "xWQ" = (
 /obj/structure/bookcase/manuals,
-/obj/effect/spawner/lootdrop/f13/traitbooks,
+/obj/item/book/granter/trait/midsurgery,
+/obj/item/book/granter/trait/chemistry,
 /turf/open/floor/f13{
 	icon_state = "bluerustysolid"
 	},


### PR DESCRIPTION
## About The Pull Request

Fixes the Farmer not having a designated spawn landmark.

## Why It's Good For The Game

Bugfix

## Pre-Merge Checklist
- [x] Your Pull Request contains no breaking changes
- [x] You tested your changes locally, and they work.
- [x] There are no new Runtimes that appear.
- [x] You documented all of your changes.

<!-- Please check these accordingly. -->

## Changelog
:cl:
fix: Spawn point for Farmer added in the appropriate place.
tweak: Reinforced metal walls along the south wall of the clinic.
tweak: Changed the random trait book spawn in the Follower Admin office to a surgery book and chemistry book.
balance: Changed the two health-HUD NVGs in the Follower Admin office to a single standard health HUD.
/:cl:
