### PR TITLE
Fixes a few mapping mistakes in the Den's shop

### DIFF
--- a/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
@@ -3518,9 +3518,6 @@
 /obj/item/weaponcrafting/reciever,
 /obj/item/advanced_crafting_components/assembly,
 /obj/item/advanced_crafting_components/assembly,
-/obj/machinery/light/small{
-	dir = 8
-	},
 /obj/item/advanced_crafting_components/receiver,
 /obj/item/advanced_crafting_components/receiver,
 /obj/structure/noticeboard{
@@ -4134,8 +4131,6 @@
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
-/obj/structure/rack,
-/obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,


### PR DESCRIPTION
Fixes the miss-placed light fixture on the northern door, and some stacked Rack objects on the eastern wall.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes the miss-placed light fixture and the stacked rack objects in the den store.

Maintains immersion, gets rid of bloat.

Before
![image](https://user-images.githubusercontent.com/38440183/133961547-7fa81dac-f1cf-4064-9a29-95659b6d51ed.png)

After
![image](https://user-images.githubusercontent.com/38440183/133961559-8c0ed04f-8470-4bc9-8410-7f3a45d15acf.png)

Where the racks were
![image](https://user-images.githubusercontent.com/38440183/133961574-9f69cdc7-fc5e-4882-b943-6e8e8f1855db.png)


<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Pre-Merge Checklist
- [X] Your Pull Request contains no breaking changes
- [X] You tested your changes locally, and they work.
- [X] There are no new Runtimes that appear.
- [X] You documented all of your changes.

<!-- Please check these accordingly. -->

## Changelog
Bobalobdob:cl:
Deleted the light fixture that was floating in midair on the northern door of the Den's shop
Deleted the two stacked rack objects next to the right wall in the Den's Shop
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
