### PR TITLE
Auto-Punctuation Fix

### DIFF
--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -388,7 +388,7 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 		message = CLOCK_CULT_SLUR(message)
 	
 	var/end_char = copytext(message, length(message), length(message) + 1)
-	if(!(end_char in list(".", "?", "!", "-", "~", ",")))
+	if(!(end_char in list(".", "?", "!", "-", "~", ",", "*", "_", "+", "|")))
 		message += "."
 
 	message = capitalize(message)

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -388,7 +388,7 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 		message = CLOCK_CULT_SLUR(message)
 	
 	var/end_char = copytext(message, length(message), length(message) + 1)
-	if(!(end_char in list(".", "?", "!", "-", "~", ",", "*", "_", "+", "|")))
+	if(!(end_char in list(".", "?", "!", "-", "~", ",", "_", "+", "|", "*")))
 		message += "."
 
 	message = capitalize(message)


### PR DESCRIPTION
Fixes auto-punctuation when radio emoting, and also when you're boldening, italicizing, or underlining your text.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
The auto-punctuation system is now perfect.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Pre-Merge Checklist
- [x] Your Pull Request contains no breaking changes
- [x] You tested your changes locally, and they work.
- [x] There are no new Runtimes that appear.
- [x] You documented all of your changes.

<!-- Please check these accordingly. -->

## Changelog
:cl:
fix: Auto-punctuation works properly when radio emoting and bolding, italicizing, or underlining your text
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
