### PR TITLE
enables daynight cycle but also uses check_tick on it because muh lighting updates

### DIFF
--- a/code/controllers/subsystem/nightcycle.dm
+++ b/code/controllers/subsystem/nightcycle.dm
@@ -41,9 +41,9 @@ SUBSYSTEM_DEF(nightcycle)
 	var/nighttime_sun_color = "#00111a"
 	var/nighttime_sun_power = 10
 	/// How does it take to get darker or brighter each step.
-	var/cycle_transition_time = 30 SECONDS
+	var/cycle_transition_time = 120 SECONDS
 	/// If defined with any number besides null it will determine how long each cycle lasts.
-	var/custom_cycle_wait = null
+	var/custom_cycle_wait = 1600 SECONDS
 	var/last_custom_cycle = 0
 
 	// Light objects
@@ -177,6 +177,7 @@ SUBSYSTEM_DEF(nightcycle)
 	var/new_junction = NONE
 	for(var/direction in GLOB.cardinals) //Cardinal case first.
 		SUNLIGHT_ADJ_IN_DIR(src, new_junction, direction, direction)
+		CHECK_TICK
 	SUNLIGHT_ADJ_IN_DIR(src, new_junction, NORTHWEST, NORTHWEST_JUNCTION)
 	SUNLIGHT_ADJ_IN_DIR(src, new_junction, NORTHEAST, NORTHEAST_JUNCTION)
 	SUNLIGHT_ADJ_IN_DIR(src, new_junction, SOUTHWEST, SOUTHWEST_JUNCTION)

--- a/code/controllers/subsystem/nightcycle.dm
+++ b/code/controllers/subsystem/nightcycle.dm
@@ -116,7 +116,7 @@ SUBSYSTEM_DEF(nightcycle)
 	animate(light_object, alpha = current_sun_power, color = current_sun_color, time = cycle_transition_time)
 	for(var/key in sunlight_border_objects)
 		animate(sunlight_border_objects[key], alpha = current_sun_power, color = current_sun_color, time = cycle_transition_time)
-
+		CHECK_TICK
 
 /datum/controller/subsystem/nightcycle/proc/get_border_object(object_key)
 	. = sunlight_border_objects["[object_key]"]
@@ -177,7 +177,6 @@ SUBSYSTEM_DEF(nightcycle)
 	var/new_junction = NONE
 	for(var/direction in GLOB.cardinals) //Cardinal case first.
 		SUNLIGHT_ADJ_IN_DIR(src, new_junction, direction, direction)
-		CHECK_TICK
 	SUNLIGHT_ADJ_IN_DIR(src, new_junction, NORTHWEST, NORTHWEST_JUNCTION)
 	SUNLIGHT_ADJ_IN_DIR(src, new_junction, NORTHEAST, NORTHEAST_JUNCTION)
 	SUNLIGHT_ADJ_IN_DIR(src, new_junction, SOUTHWEST, SOUTHWEST_JUNCTION)


### PR DESCRIPTION
## About The Pull Request

re-adds day/night and adds lag checks. improved the transition time so it no longer looks like a lamp being turned off, and actually should slowly fade and get brighter overtime respectively.


## Pre-Merge Checklist
- [x] Your Pull Request contains no breaking changes
- [x] You tested your changes locally, and they work.
- [x] There are no new Runtimes that appear.
- [x] You documented all of your changes.

<!-- Please check these accordingly. -->

## Changelog
:cl:
tweak: re-enabled daynight and adjusted it for ticklag

/:cl:

