### PR TITLE
Disables Hotrod and Raider PA from spawning

### DIFF
--- a/code/_globalvars/lists/maintenance_loot.dm
+++ b/code/_globalvars/lists/maintenance_loot.dm
@@ -393,9 +393,7 @@ GLOBAL_LIST_INIT(loot_t4_armor, list(
 	/obj/item/clothing/suit/armor/f13/combat/mk2,
 	/obj/item/clothing/head/helmet/f13/combat/mk2,
 	/obj/item/clothing/suit/armor/f13/power_armor/raiderpa,
-	/obj/item/clothing/head/helmet/f13/power_armor/raiderpa_helm,
-	/obj/item/clothing/suit/armor/f13/power_armor/hotrod,
-	/obj/item/clothing/head/helmet/f13/power_armor/hotrod
+	/obj/item/clothing/head/helmet/f13/power_armor/raiderpa_helm
 ))
 
 GLOBAL_LIST_INIT(loot_t5_armor, list(

--- a/code/_globalvars/lists/maintenance_loot.dm
+++ b/code/_globalvars/lists/maintenance_loot.dm
@@ -391,9 +391,7 @@ GLOBAL_LIST_INIT(loot_t4_armor, list(
 	/obj/item/clothing/suit/armor/f13/leather_jacket/combat/riotpolice,
 	/obj/item/clothing/head/helmet/f13/rangerbroken,
 	/obj/item/clothing/suit/armor/f13/combat/mk2,
-	/obj/item/clothing/head/helmet/f13/combat/mk2,
-	/obj/item/clothing/suit/armor/f13/power_armor/raiderpa,
-	/obj/item/clothing/head/helmet/f13/power_armor/raiderpa_helm
+	/obj/item/clothing/head/helmet/f13/combat/mk2
 ))
 
 GLOBAL_LIST_INIT(loot_t5_armor, list(

--- a/code/datums/components/crafting/recipes/recipes_tailoring.dm
+++ b/code/datums/components/crafting/recipes/recipes_tailoring.dm
@@ -131,17 +131,6 @@
 	category = CAT_CLOTHING
 	subcategory = CAT_ARMOR
 
-/datum/crafting_recipe/raiderpaconversion
-	name = "Salvaged Power Armor Raider"
-	result = /obj/item/clothing/suit/armor/f13/power_armor/raiderpa
-	reqs = list(/obj/item/clothing/suit/armor/f13/power_armor/t45b  = 1,
-				/obj/item/stack/sheet/metal = 10,
-				/obj/item/stack/crafting/electronicparts = 5)
-	tools = list(TOOL_WORKBENCH)
-	time = 60
-	category = CAT_CLOTHING
-	subcategory = CAT_ARMOR
-
 /datum/crafting_recipe/raiderpahelmconversion
 	name = "Salvaged Power Armor Helmet Raider"
 	result = /obj/item/clothing/head/helmet/f13/power_armor/raiderpa_helm

--- a/code/datums/components/crafting/recipes/recipes_tailoring.dm
+++ b/code/datums/components/crafting/recipes/recipes_tailoring.dm
@@ -131,28 +131,6 @@
 	category = CAT_CLOTHING
 	subcategory = CAT_ARMOR
 
-/datum/crafting_recipe/raiderpahelmconversion
-	name = "Salvaged Power Armor Helmet Raider"
-	result = /obj/item/clothing/head/helmet/f13/power_armor/raiderpa_helm
-	reqs = list(/obj/item/clothing/head/helmet/f13/power_armor/t45b = 1,
-				/obj/item/stack/sheet/metal = 10,
-				/obj/item/stack/crafting/electronicparts = 5)
-	tools = list(TOOL_WORKBENCH)
-	time = 60
-	category = CAT_CLOTHING
-	subcategory = CAT_ARMOR
-
-/datum/crafting_recipe/hotrodpahelmconversion
-	name = "Salvaged Power Armor Helmet Hot Rod"
-	result = /obj/item/clothing/head/helmet/f13/power_armor/hotrod
-	reqs = list(/obj/item/clothing/head/helmet/f13/power_armor/t45b = 1,
-				/obj/item/stack/sheet/metal = 10,
-				/obj/item/stack/crafting/electronicparts = 5)
-	tools = list(TOOL_WORKBENCH)
-	time = 60
-	category = CAT_CLOTHING
-	subcategory = CAT_ARMOR
-
 /datum/crafting_recipe/ncrsalvagedarmorconversion
 	name = "Salvaged NCR Power Armor"
 	result = /obj/item/clothing/suit/armor/f13/power_armor/ncr

--- a/code/datums/components/crafting/recipes/recipes_tailoring.dm
+++ b/code/datums/components/crafting/recipes/recipes_tailoring.dm
@@ -153,17 +153,6 @@
 	category = CAT_CLOTHING
 	subcategory = CAT_ARMOR
 
-/datum/crafting_recipe/hotrodpaconversion
-	name = "Salvaged Power Armor Hot Rod"
-	result = /obj/item/clothing/suit/armor/f13/power_armor/hotrod
-	reqs = list(/obj/item/clothing/suit/armor/f13/power_armor/t45b  = 1,
-				/obj/item/stack/sheet/metal = 10,
-				/obj/item/stack/crafting/electronicparts = 5)
-	tools = list(TOOL_WORKBENCH)
-	time = 60
-	category = CAT_CLOTHING
-	subcategory = CAT_ARMOR
-
 /datum/crafting_recipe/hotrodpahelmconversion
 	name = "Salvaged Power Armor Helmet Hot Rod"
 	result = /obj/item/clothing/head/helmet/f13/power_armor/hotrod

--- a/code/game/objects/effects/spawners/f13lootdrop.dm
+++ b/code/game/objects/effects/spawners/f13lootdrop.dm
@@ -367,8 +367,7 @@
 				/obj/effect/spawner/bundle/f13/armor/t45b,
 				/obj/effect/spawner/bundle/f13/armor/riot,
 				/obj/effect/spawner/bundle/f13/armor/combat/mk2,
-				/obj/effect/spawner/bundle/f13/armor/combat/mk2/dark,
-				/obj/effect/spawner/bundle/f13/armor/raiderpa
+				/obj/effect/spawner/bundle/f13/armor/combat/mk2/dark
 				)
 
 /obj/effect/spawner/bundle/f13/armor/t45b

--- a/code/game/objects/effects/spawners/f13lootdrop.dm
+++ b/code/game/objects/effects/spawners/f13lootdrop.dm
@@ -368,8 +368,7 @@
 				/obj/effect/spawner/bundle/f13/armor/riot,
 				/obj/effect/spawner/bundle/f13/armor/combat/mk2,
 				/obj/effect/spawner/bundle/f13/armor/combat/mk2/dark,
-				/obj/effect/spawner/bundle/f13/armor/raiderpa,
-				/obj/effect/spawner/bundle/f13/armor/hotrodpa
+				/obj/effect/spawner/bundle/f13/armor/raiderpa
 				)
 
 /obj/effect/spawner/bundle/f13/armor/t45b

--- a/code/modules/fallout/misc/gang_items.dm
+++ b/code/modules/fallout/misc/gang_items.dm
@@ -87,19 +87,6 @@
 	cost = 100
 	item_path = /obj/item/clothing/suit/toggle/labcoat/f13/khan_jacket_armored
 
-/datum/gang_item/clothing/raiderpa
-	name = "Salvaged Raider Power Armor"
-	id = "raider_power_armor"
-	cost = 1600
-	item_path = /obj/item/clothing/suit/armor/f13/power_armor/raiderpa
-
-/datum/gang_item/clothing/raiderpa_helmet
-	name = "Salvaged Raider Power Armor Helmet"
-	id = "raider_power_armor_helmet"
-	cost = 800
-	item_path = /obj/item/clothing/head/helmet/f13/power_armor/raiderpa_helm
-
-
 /datum/gang_item/clothing/prostitute_dress
 	name = "Prostitute dress"
 	id = "prostitute_dress"

--- a/code/modules/fallout/misc/gangs.dm
+++ b/code/modules/fallout/misc/gangs.dm
@@ -96,10 +96,7 @@ GLOBAL_DATUM_INIT(denmob, /datum/gang/denmob, new)
 		/datum/gang_item/weapon/greasegun,
 		/datum/gang_item/clothing/glasses/sunglasses,
 		/datum/gang_item/weapon/type17,
-		/datum/gang_item/weapon/type93,
-
-		/datum/gang_item/clothing/raiderpa,
-		/datum/gang_item/clothing/raiderpa_helmet
+		/datum/gang_item/weapon/type93
 	)
 
 /datum/gang/New(starting_members, starting_leader)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Stops Hotrod and Raider PA from spawning. Admins can still bus it in, and it's still in VR. 

## Why It's Good For The Game

Hotrod and Raider PA isn't exactly a very immersive armor and there has been expressed desire to remove it.

## Pre-Merge Checklist
- [X] Your Pull Request contains no breaking changes
- [X] You tested your changes locally, and they work.
- [X] There are no new Runtimes that appear.
- [X] You documented all of your changes.

<!-- Please check these accordingly. -->

## Changelog
:cl:
del: Hotrod and Raider PA no longer spawns.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
