### PR TITLE
Renames Space Cleaner to Abraxo Cleaner

### DIFF
--- a/code/datums/components/crafting/recipes/recipes_medicine.dm
+++ b/code/datums/components/crafting/recipes/recipes_medicine.dm
@@ -3,7 +3,7 @@
 	result = /obj/item/stack/medical/gauze/adv/one
 	time = 50
 	reqs = list(/obj/item/stack/medical/gauze = 1,
-				/datum/reagent/space_cleaner/sterilizine = 10)
+				/datum/reagent/abraxo_cleaner/sterilizine = 10)
 	category = CAT_MEDICAL
 	blacklist = list(/obj/item/stack/medical/gauze/improvised)
 

--- a/code/datums/wounds/burns.dm
+++ b/code/datums/wounds/burns.dm
@@ -39,7 +39,7 @@
 	if(victim.reagents)
 		if(victim.reagents.has_reagent(/datum/reagent/medicine/spaceacillin))
 			sanitization += 0.9
-		if(victim.reagents.has_reagent(/datum/reagent/space_cleaner/sterilizine/))
+		if(victim.reagents.has_reagent(/datum/reagent/abraxo_cleaner/sterilizine/))
 			sanitization += 0.9
 		if(victim.reagents.has_reagent(/datum/reagent/medicine/mine_salve))
 			sanitization += 0.3

--- a/code/game/objects/items/grenades/chem_grenade.dm
+++ b/code/game/objects/items/grenades/chem_grenade.dm
@@ -399,7 +399,7 @@
 
 /obj/item/grenade/chem_grenade/cleaner
 	name = "cleaner grenade"
-	desc = "BLAM!-brand foaming space cleaner. In a special applicator for rapid cleaning of wide areas."
+	desc = "Abraxo-brand foaming cleaner. In a special applicator for rapid cleaning of wide areas."
 	stage = READY
 
 /obj/item/grenade/chem_grenade/cleaner/Initialize()
@@ -409,7 +409,7 @@
 
 	B1.reagents.add_reagent(/datum/reagent/fluorosurfactant, 40)
 	B2.reagents.add_reagent(/datum/reagent/water, 40)
-	B2.reagents.add_reagent(/datum/reagent/space_cleaner, 10)
+	B2.reagents.add_reagent(/datum/reagent/abraxo_cleaner, 10)
 
 	beakers += B1
 	beakers += B2
@@ -427,7 +427,7 @@
 
 	B1.reagents.add_reagent(/datum/reagent/fluorosurfactant, 40)
 	B2.reagents.add_reagent(/datum/reagent/water, 40)
-	B2.reagents.add_reagent(/datum/reagent/space_cleaner/ez_clean, 60) //ensures a  t h i c c  distribution
+	B2.reagents.add_reagent(/datum/reagent/abraxo_cleaner/ez_clean, 60) //ensures a  t h i c c  distribution
 
 	beakers += B1
 	beakers += B2

--- a/code/game/objects/items/mop.dm
+++ b/code/game/objects/items/mop.dm
@@ -25,7 +25,7 @@
 
 
 /obj/item/mop/proc/clean(turf/A)
-	if(reagents.has_reagent(/datum/reagent/water, 1) || reagents.has_reagent(/datum/reagent/water/holywater, 1) || reagents.has_reagent(/datum/reagent/consumable/ethanol/vodka, 1) || reagents.has_reagent(/datum/reagent/space_cleaner, 1))
+	if(reagents.has_reagent(/datum/reagent/water, 1) || reagents.has_reagent(/datum/reagent/water/holywater, 1) || reagents.has_reagent(/datum/reagent/consumable/ethanol/vodka, 1) || reagents.has_reagent(/datum/reagent/abraxo_cleaner, 1))
 		SEND_SIGNAL(A, COMSIG_COMPONENT_CLEAN_ACT, CLEAN_MEDIUM)
 		A.clean_blood()
 		for(var/obj/effect/O in A)

--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -179,12 +179,12 @@
 					"<span class='notice'>You cut [src] into pieces of cloth with [I].</span>", \
 					"<span class='italics'>You hear cutting.</span>")
 		use(2)
-	else if(I.is_drainable() && I.reagents.has_reagent(/datum/reagent/space_cleaner/sterilizine))
-		if(!I.reagents.has_reagent(/datum/reagent/space_cleaner/sterilizine, 10))
+	else if(I.is_drainable() && I.reagents.has_reagent(/datum/reagent/abraxo_cleaner/sterilizine))
+		if(!I.reagents.has_reagent(/datum/reagent/abraxo_cleaner/sterilizine, 10))
 			to_chat(user, "<span class='warning'>There's not enough sterilizine in [I] to sterilize [src]!</span>")
 			return
 		user.visible_message("<span class='notice'>[user] pours the contents of [I] onto [src], sterilizing it.</span>", "<span class='notice'>You pour the contents of [I] onto [src], sterilizing it.</span>")
-		I.reagents.remove_reagent(/datum/reagent/space_cleaner/sterilizine, 10)
+		I.reagents.remove_reagent(/datum/reagent/abraxo_cleaner/sterilizine, 10)
 		new /obj/item/stack/medical/gauze/adv/one(user.drop_location())
 		use(1)
 	else

--- a/code/game/objects/items/tanks/watertank.dm
+++ b/code/game/objects/items/tanks/watertank.dm
@@ -149,7 +149,7 @@
 
 /obj/item/watertank/janitor/Initialize()
 	. = ..()
-	reagents.add_reagent(/datum/reagent/space_cleaner, 500)
+	reagents.add_reagent(/datum/reagent/abraxo_cleaner, 500)
 
 /obj/item/reagent_containers/spray/mister/janitor
 	name = "janitor spray nozzle"

--- a/code/modules/clothing/suits/miscellaneous.dm
+++ b/code/modules/clothing/suits/miscellaneous.dm
@@ -745,13 +745,13 @@
 
 /obj/item/clothing/suit/hooded/wintercoat/janitor
 	name = "janitors winter coat"
-	desc = "(I) A purple-and-beige winter coat that smells of space cleaner."
+	desc = "(I) A purple-and-beige winter coat that smells of Abraxo-brand cleaner."
 	icon_state = "coatjanitor"
 	item_state = "coatjanitor"
 	hoodtype = /obj/item/clothing/head/hooded/winterhood/janitor
 
 /obj/item/clothing/head/hooded/winterhood/janitor
-	desc = "(I) A purple hood that smells of space cleaner."
+	desc = "(I) A purple hood that smells of Abraxo-brand cleaner."
 	icon_state = "winterhood_janitor"
 
 /obj/item/clothing/suit/hooded/wintercoat/cargo

--- a/code/modules/events/vent_clog.dm
+++ b/code/modules/events/vent_clog.dm
@@ -17,7 +17,7 @@
 		/datum/reagent/water,
 		/datum/reagent/carbon,
 		/datum/reagent/consumable/flour,
-		/datum/reagent/space_cleaner,
+		/datum/reagent/abraxo_cleaner,
 		/datum/reagent/consumable/nutriment,
 		/datum/reagent/consumable/condensedcapsaicin,
 		/datum/reagent/drug/mushroomhallucinogen,

--- a/code/modules/food_and_drinks/kitchen_machinery/microwave.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/microwave.dm
@@ -141,14 +141,14 @@
 
 	if(istype(O, /obj/item/reagent_containers/spray))
 		var/obj/item/reagent_containers/spray/clean_spray = O
-		if(clean_spray.reagents.has_reagent(/datum/reagent/space_cleaner, clean_spray.amount_per_transfer_from_this))
-			clean_spray.reagents.remove_reagent(/datum/reagent/space_cleaner, clean_spray.amount_per_transfer_from_this,1)
+		if(clean_spray.reagents.has_reagent(/datum/reagent/abraxo_cleaner, clean_spray.amount_per_transfer_from_this))
+			clean_spray.reagents.remove_reagent(/datum/reagent/abraxo_cleaner, clean_spray.amount_per_transfer_from_this,1)
 			playsound(loc, 'sound/effects/spray3.ogg', 50, 1, -6)
 			user.visible_message("[user] has cleaned \the [src].", "<span class='notice'>You clean \the [src].</span>")
 			dirty = 0
 			update_icon()
 		else
-			to_chat(user, "<span class='warning'>You need more space cleaner!</span>")
+			to_chat(user, "<span class='warning'>You need more cleaning agent!</span>")
 		return TRUE
 
 	if(istype(O, /obj/item/soap))

--- a/code/modules/food_and_drinks/recipes/drinks_recipes.dm
+++ b/code/modules/food_and_drinks/recipes/drinks_recipes.dm
@@ -1044,7 +1044,7 @@
 	name = "Rotgut"
 	id = /datum/reagent/consumable/ethanol/rotgut
 	results = list(/datum/reagent/consumable/ethanol/rotgut = 5)
-	required_reagents = list(/datum/reagent/space_cleaner = 1, /datum/reagent/consumable/ethanol/whiskey = 2, /datum/reagent/oil = 1, /datum/reagent/consumable/ethanol = 1)
+	required_reagents = list(/datum/reagent/abraxo_cleaner = 1, /datum/reagent/consumable/ethanol/whiskey = 2, /datum/reagent/oil = 1, /datum/reagent/consumable/ethanol = 1)
 
 /datum/chemical_reaction/nukavictory
 	name = "Nuka Victory"

--- a/code/modules/hydroponics/grown/flowers.dm
+++ b/code/modules/hydroponics/grown/flowers.dm
@@ -296,7 +296,7 @@
 	icon_grow = "bee_balm-grow"
 	icon_dead = "bee_balm-dead"
 	mutatelist = list(/obj/item/seeds/poppy/geranium, /obj/item/seeds/bee_balm/honey_balm) //Lower odds of becoming honey
-	reagents_add = list(/datum/reagent/medicine/spaceacillin = 0.1, /datum/reagent/space_cleaner/sterilizine = 0.05)
+	reagents_add = list(/datum/reagent/medicine/spaceacillin = 0.1, /datum/reagent/abraxo_cleaner/sterilizine = 0.05)
 
 /obj/item/reagent_containers/food/snacks/grown/bee_balm
 	seed = /obj/item/seeds/bee_balm

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1148,14 +1148,14 @@
 				GG = new/obj/effect/decal/cleanable/greenglow(T)
 			GG.reagents.add_reagent(/datum/reagent/radium, reac_volume)
 
-/datum/reagent/space_cleaner/sterilizine
+/datum/reagent/abraxo_cleaner/sterilizine
 	name = "Sterilizine"
 	description = "Sterilizes wounds in preparation for surgery."
 	color = "#e6f1f5" // rgb: 200, 165, 220
 	taste_description = "bitterness"
 	pH = 10.5
 
-/datum/reagent/space_cleaner/sterilizine/reaction_mob(mob/living/carbon/C, method=TOUCH, reac_volume)
+/datum/reagent/abraxo_cleaner/sterilizine/reaction_mob(mob/living/carbon/C, method=TOUCH, reac_volume)
 	if(method in list(TOUCH, VAPOR, PATCH))
 		for(var/s in C.surgeries)
 			var/datum/surgery/S = s
@@ -1163,7 +1163,7 @@
 			// +20% success propability on each step, useful while operating in less-than-perfect conditions
 	..()
 
-/datum/reagent/space_cleaner/sterilizine/reaction_obj(obj/O, reac_volume)
+/datum/reagent/abraxo_cleaner/sterilizine/reaction_obj(obj/O, reac_volume)
 	if(istype(O, /obj/item/stack/medical/gauze))
 		var/obj/item/stack/medical/gauze/G = O
 		reac_volume = min((reac_volume / 10), G.amount)
@@ -1335,14 +1335,14 @@
 	..()
 	return TRUE
 
-/datum/reagent/space_cleaner
-	name = "Space cleaner"
+/datum/reagent/abraxo_cleaner
+	name = "Abraxo cleaner"
 	description = "A compound used to clean things. Now with 50% more sodium hypochlorite!"
 	color = "#A5F0EE" // rgb: 165, 240, 238
 	taste_description = "sourness"
 	pH = 5.5
 
-/datum/reagent/space_cleaner/reaction_obj(obj/O, reac_volume)
+/datum/reagent/abraxo_cleaner/reaction_obj(obj/O, reac_volume)
 	if(istype(O, /obj/effect/decal/cleanable)  || istype(O, /obj/item/projectile/bullet/reusable/foam_dart) || istype(O, /obj/item/ammo_casing/caseless/foam_dart))
 		qdel(O)
 	else
@@ -1351,7 +1351,7 @@
 			SEND_SIGNAL(O, COMSIG_COMPONENT_CLEAN_ACT, CLEAN_WEAK)
 			O.clean_blood()
 
-/datum/reagent/space_cleaner/reaction_turf(turf/T, reac_volume)
+/datum/reagent/abraxo_cleaner/reaction_turf(turf/T, reac_volume)
 	if(reac_volume >= 1)
 		T.remove_atom_colour(WASHABLE_COLOUR_PRIORITY)
 		SEND_SIGNAL(T, COMSIG_COMPONENT_CLEAN_ACT, CLEAN_WEAK)
@@ -1362,7 +1362,7 @@
 		for(var/mob/living/simple_animal/slime/M in T)
 			M.adjustToxLoss(rand(5,10))
 
-/datum/reagent/space_cleaner/reaction_mob(mob/living/M, method=TOUCH, reac_volume)
+/datum/reagent/abraxo_cleaner/reaction_mob(mob/living/M, method=TOUCH, reac_volume)
 	if(method == TOUCH || method == VAPOR)
 		M.remove_atom_colour(WASHABLE_COLOUR_PRIORITY)
 		if(iscarbon(M))
@@ -1401,7 +1401,7 @@
 			SEND_SIGNAL(M, COMSIG_COMPONENT_CLEAN_ACT, CLEAN_WEAK)
 			M.clean_blood()
 
-/datum/reagent/space_cleaner/ez_clean
+/datum/reagent/abraxo_cleaner/ez_clean
 	name = "EZ Clean"
 	description = "A powerful, acidic cleaner sold by Waffle Co. Affects organic matter while leaving other objects unaffected."
 	metabolization_rate = 1.5 * REAGENTS_METABOLISM
@@ -1409,13 +1409,13 @@
 	pH = 2
 	value = REAGENT_VALUE_RARE
 
-/datum/reagent/space_cleaner/ez_clean/on_mob_life(mob/living/carbon/M)
+/datum/reagent/abraxo_cleaner/ez_clean/on_mob_life(mob/living/carbon/M)
 	M.adjustBruteLoss(3.33)
 	M.adjustFireLoss(3.33)
 	M.adjustToxLoss(3.33)
 	..()
 
-/datum/reagent/space_cleaner/ez_clean/reaction_mob(mob/living/M, method=TOUCH, reac_volume)
+/datum/reagent/abraxo_cleaner/ez_clean/reaction_mob(mob/living/M, method=TOUCH, reac_volume)
 	..()
 	if((method == TOUCH || method == VAPOR) && !issilicon(M))
 		M.adjustBruteLoss(1)

--- a/code/modules/reagents/chemistry/recipes/drugs.dm
+++ b/code/modules/reagents/chemistry/recipes/drugs.dm
@@ -17,7 +17,7 @@
 	name = "Krokodil"
 	id = /datum/reagent/drug/krokodil
 	results = list(/datum/reagent/drug/krokodil = 6)
-	required_reagents = list(/datum/reagent/medicine/diphenhydramine = 1, /datum/reagent/medicine/morphine = 1, /datum/reagent/space_cleaner = 1, /datum/reagent/potassium = 1, /datum/reagent/phosphorus = 1, /datum/reagent/fuel = 1)
+	required_reagents = list(/datum/reagent/medicine/diphenhydramine = 1, /datum/reagent/medicine/morphine = 1, /datum/reagent/abraxo_cleaner = 1, /datum/reagent/potassium = 1, /datum/reagent/phosphorus = 1, /datum/reagent/fuel = 1)
 	mix_message = "The mixture dries into a pale blue powder."
 	required_temp = 380
 
@@ -40,7 +40,7 @@
 	name = "bath_salts"
 	id = /datum/reagent/drug/bath_salts
 	results = list(/datum/reagent/drug/bath_salts = 7)
-	required_reagents = list(/datum/reagent/toxin/bad_food = 1, /datum/reagent/saltpetre = 1, /datum/reagent/consumable/nutriment = 1, /datum/reagent/space_cleaner = 1, /datum/reagent/consumable/enzyme = 1, /datum/reagent/consumable/tea = 1, /datum/reagent/mercury = 1)
+	required_reagents = list(/datum/reagent/toxin/bad_food = 1, /datum/reagent/saltpetre = 1, /datum/reagent/consumable/nutriment = 1, /datum/reagent/abraxo_cleaner = 1, /datum/reagent/consumable/enzyme = 1, /datum/reagent/consumable/tea = 1, /datum/reagent/mercury = 1)
 	required_temp = 374
 
 /datum/chemical_reaction/aranesp

--- a/code/modules/reagents/chemistry/recipes/medicine.dm
+++ b/code/modules/reagents/chemistry/recipes/medicine.dm
@@ -346,7 +346,7 @@ datum/chemical_reaction/rezadone
 		new /obj/item/stack/medical/suture/medicated(location)
 
 /datum/chemical_reaction/medmesh
-	required_reagents = list(/datum/reagent/cellulose = 20, /datum/reagent/consumable/aloejuice = 20, /datum/reagent/space_cleaner/sterilizine = 10)
+	required_reagents = list(/datum/reagent/cellulose = 20, /datum/reagent/consumable/aloejuice = 20, /datum/reagent/abraxo_cleaner/sterilizine = 10)
 
 /datum/chemical_reaction/medmesh/on_reaction(datum/reagents/holder, created_volume)
 	var/location = get_turf(holder.my_atom)

--- a/code/modules/reagents/chemistry/recipes/others.dm
+++ b/code/modules/reagents/chemistry/recipes/others.dm
@@ -33,7 +33,7 @@
 /datum/chemical_reaction/sterilizine
 	name = "Sterilizine"
 	id = "sterilizine"
-	results = list(/datum/reagent/space_cleaner/sterilizine = 3)
+	results = list(/datum/reagent/abraxo_cleaner/sterilizine = 3)
 	required_reagents = list(/datum/reagent/consumable/ethanol = 1, /datum/reagent/medicine/charcoal = 1, /datum/reagent/chlorine = 1)
 
 /datum/chemical_reaction/lube
@@ -551,9 +551,9 @@
 	required_reagents = list (/datum/reagent/ammonia = 1, /datum/reagent/consumable/ethanol = 1)
 
 /datum/chemical_reaction/space_cleaner
-	name = "Space cleaner"
-	id = /datum/reagent/space_cleaner
-	results = list(/datum/reagent/space_cleaner = 2)
+	name = "Abraxo cleaner"
+	id = /datum/reagent/abraxo_cleaner
+	results = list(/datum/reagent/abraxo_cleaner = 2)
 	required_reagents = list(/datum/reagent/ammonia = 1, /datum/reagent/water = 1)
 
 /datum/chemical_reaction/plantbgone

--- a/code/modules/reagents/reagent_containers/medspray.dm
+++ b/code/modules/reagents/reagent_containers/medspray.dm
@@ -101,8 +101,8 @@
 
 /obj/item/reagent_containers/medspray/sterilizine
 	name = "sterilizer spray"
-	desc = "Spray bottle loaded with non-toxic sterilizer. Useful in preparation for surgery."
-	list_reagents = list(/datum/reagent/space_cleaner/sterilizine = 60)
+	desc = "Spray bottle loaded with non-toxic sterilizer from Abraxodyne Chemical. Useful in preparation for surgery."
+	list_reagents = list(/datum/reagent/abraxo_cleaner/sterilizine = 60)
 
 /obj/item/reagent_containers/medspray/synthtissue
 	name = "Synthtissue young culture spray"

--- a/code/modules/reagents/reagent_containers/spray.dm
+++ b/code/modules/reagents/reagent_containers/spray.dm
@@ -151,12 +151,12 @@
 		reagents.reaction(usr.loc)
 		src.reagents.clear_reagents()
 
-//space cleaner
+//abraxo cleaner
 /obj/item/reagent_containers/spray/cleaner
-	name = "space cleaner"
-	desc = "BLAM!-brand non-foaming space cleaner!"
+	name = "Abraxo cleaner"
+	desc = "Abraxo-brand non-foaming cleaner cleaner!"
 	volume = 100
-	list_reagents = list(/datum/reagent/space_cleaner = 100)
+	list_reagents = list(/datum/reagent/abraxo_cleaner = 100)
 	amount_per_transfer_from_this = 2
 	stream_amount = 5
 

--- a/code/modules/reagents/reagent_containers/spray.dm
+++ b/code/modules/reagents/reagent_containers/spray.dm
@@ -154,7 +154,7 @@
 //abraxo cleaner
 /obj/item/reagent_containers/spray/cleaner
 	name = "Abraxo cleaner"
-	desc = "Abraxo-brand non-foaming cleaner cleaner!"
+	desc = "Abraxo-brand non-foaming cleaner!"
 	volume = 100
 	list_reagents = list(/datum/reagent/abraxo_cleaner = 100)
 	amount_per_transfer_from_this = 2

--- a/code/modules/surgery/embalming.dm
+++ b/code/modules/surgery/embalming.dm
@@ -13,7 +13,7 @@
 /datum/surgery_step/embalming
 	name = "embalming body"
 	implements = list(TOOL_HEMOSTAT = 100, TOOL_SCREWDRIVER = 35)
-	chems_needed = list(/datum/reagent/drying_agent, /datum/reagent/space_cleaner/sterilizine)
+	chems_needed = list(/datum/reagent/drying_agent, /datum/reagent/abraxo_cleaner/sterilizine)
 	require_all_chems = FALSE
 
 /datum/surgery_step/embalming/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The Abraxodyne Chemical Company made a pre-war chemical called Abraxo-Cleaner and it's still found, and effective, in the post-war period. Impressive. 

## Why It's Good For The Game

Immersion change.

## Pre-Merge Checklist
- [X] Your Pull Request contains no breaking changes
- [X] You tested your changes locally, and they work.
- [X] There are no new Runtimes that appear.
- [X] You documented all of your changes.

<!-- Please check these accordingly. -->

## Changelog
:cl:
tweak: Space cleaner is now Abraxo-Brand cleaner.

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
