### PR TITLE
burn wound lazyfix

### DIFF
--- a/code/datums/wounds/burns.dm
+++ b/code/datums/wounds/burns.dm
@@ -97,6 +97,10 @@
 			else if(prob(4))
 				victim.adjustToxLoss(1)
 		if(WOUND_INFECTION_SEPTIC to INFINITY)
+			victim.adjustToxLoss(0.5) //When the infection is septic, toxin damage isn't a roll of the dice anymore, it's happening.
+			if (limb.body_zone == BODY_ZONE_HEAD || limb.body_zone == BODY_ZONE_CHEST) //These limbs will never be permanently destroyed, but they've got vital organs. When they reach septic level, they deal more tox damage.
+				victim.adjustToxLoss(1)
+				return
 			if(prob(infestation))
 				switch(strikes_to_lose_limb)
 					if(3 to INFINITY)


### PR DESCRIPTION
i got tired of chests and heads going necrotic and requiring augumentations

now they can't go completely dead and render you untreatable without an augumentation anymore but they'll deal constant toxin damage until the burn's fixed

## Pre-Merge Checklist
- [ ] Your Pull Request contains no breaking changes
- [ ] You tested your changes locally, and they work.
- [ ] There are no new Runtimes that appear.
- [ ] You documented all of your changes.

<!-- Please check these accordingly. -->

## Changelog
:cl:
tweak: your head and chest can no longer be rendered completely necrotic and dead by burns but going septic will inflict more toxin damage by far in those areas
/:cl:
