### PR TITLE
does a small fix to gun melee before i eventually remove PBing entirely

### DIFF
--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -463,7 +463,7 @@ ATTACHMENTS
 		return FALSE
 
 /obj/item/gun/CheckAttackCooldown(mob/user, atom/target)
-	if((user.a_intent == INTENT_HARM) && user.Adjacent(target))		//melee
+	if((user.a_intent == INTENT_HARM || INTENT_HELP) && user.Adjacent(target))		//melee
 		return user.CheckActionCooldown(CLICK_CD_MELEE)
 	return user.CheckActionCooldown(get_clickcd())
 


### PR DESCRIPTION
turns out whacking people with a gun on help intent makes you whack faster than is normally acceptable for guns, meaning that you'd whack and keep shooting fast

they should have greater delay than melee weapons as a consequence 

## Pre-Merge Checklist
- [ ] Your Pull Request contains no breaking changes
- [ ] You tested your changes locally, and they work.
- [ ] There are no new Runtimes that appear.
- [ ] You documented all of your changes.

<!-- Please check these accordingly. -->

## Changelog
:cl:
fix: fixes an oversight relating to gun attackspeed and intents
/:cl:

