### PR TITLE
attacking things in melee no longer comes with screenshake (wtf) and stamina loss (wtf)

### DIFF
--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -123,20 +123,6 @@
 	if (force >= 5 && HAS_TRAIT(user, TRAIT_BUFFOUT_BUFF))
 		force -= buffout
 
-	var/weight = getweight(user, STAM_COST_ATTACK_MOB_MULT) //CIT CHANGE - makes attacking things cause stamina loss
-	if(weight)
-		user.adjustStaminaLossBuffered(weight)
-
-	// CIT SCREENSHAKE
-	if(force >= 15)
-		shake_camera(user, ((force - 10) * 0.01 + 1), ((force - 10) * 0.01))
-		if(M.client)
-			switch (M.client.prefs.damagescreenshake)
-				if (1)
-					shake_camera(M, ((force - 10) * 0.015 + 1), ((force - 10) * 0.015))
-				if (2)
-					if(!CHECK_MOBILITY(M, MOBILITY_MOVE))
-						shake_camera(M, ((force - 10) * 0.015 + 1), ((force - 10) * 0.015))
 
 //the equivalent of the standard version of attack() but for object targets.
 /obj/item/proc/attack_obj(obj/O, mob/living/user)
@@ -146,9 +132,6 @@
 		return
 	user.do_attack_animation(O)
 	O.attacked_by(src, user)
-	var/weight = getweight(user, STAM_COST_ATTACK_OBJ_MULT)
-	if(weight)
-		user.adjustStaminaLossBuffered(weight)//CIT CHANGE - makes attacking things cause stamina loss
 
 /atom/movable/proc/attacked_by()
 	return


### PR DESCRIPTION
stamina combat was a fucking mistake

## Pre-Merge Checklist
- [ ] Your Pull Request contains no breaking changes
- [ ] You tested your changes locally, and they work.
- [ ] There are no new Runtimes that appear.
- [ ] You documented all of your changes.

<!-- Please check these accordingly. -->

## Changelog
:cl:
del: Removes stamina loss and screenshake from melee attacks
fix: fixed a few things
/:cl:
