### PR TITLE
Low tier shotguns fixed

### DIFF
--- a/code/modules/projectiles/guns/ballistic.dm
+++ b/code/modules/projectiles/guns/ballistic.dm
@@ -220,7 +220,7 @@
 		name = "sawn-off [src.name]"
 		desc = sawn_desc
 		w_class = WEIGHT_CLASS_NORMAL
-		weapon_weight = WEAPON_LIGHT //Possible to fire one from each hand. Let's see how it pans out.
+		weapon_weight = WEAPON_HEAVY //No longer possible to fire one from each hand. Let's see how it pans out.
 		item_state = "gun"
 		slot_flags &= ~ITEM_SLOT_BACK	//you can't sling it on your back
 		slot_flags |= ITEM_SLOT_BELT		//but you can wear it on your belt (poorly concealed under a trenchcoat, ideally)

--- a/code/modules/projectiles/guns/ballistic/shotgun.dm
+++ b/code/modules/projectiles/guns/ballistic/shotgun.dm
@@ -108,7 +108,7 @@
 	item_state = "shotgundouble"
 	w_class = WEIGHT_CLASS_BULKY
 	weapon_weight = WEAPON_HEAVY
-	fire_delay = 0.5
+	fire_delay = 5
 	force = 20
 	mag_type = /obj/item/ammo_box/magazine/internal/shot/dual/simple
 	sawn_desc = "Short and concealable, terribly uncomfortable to fire, but worse on the other end."
@@ -144,7 +144,7 @@
 	mag_type = /obj/item/ammo_box/magazine/internal/shot/dual
 	w_class = WEIGHT_CLASS_BULKY
 	weapon_weight = WEAPON_HEAVY
-	fire_delay = 0.5
+	fire_delay = 5
 	force = 20
 	sawn_desc = "Someone took the time to chop the last few inches off the barrel and stock of this shotgun. Now, the wide spread of this hand-cannon's short-barreled shots makes it perfect for short-range crowd control."
 	fire_sound = 'sound/f13weapons/max_sawn_off.ogg'


### PR DESCRIPTION
Ah yes. Point blank but actually stronger. And it's from incredibly common low-tier guns.

This basically just adds a fire delay to the double barrelled shotguns and makes sawn-offs unfireable from one hand. Essentially just makes pump shotguns actually useful to some degree again. They should now be around equal in power to the other guns of their tier, which... is good since the spawns and incredibly simple and easy crafting recipe are there with that in mind.