### PR TITLE
Event Stuff

### DIFF
--- a/code/datums/weather/weather_types/rain.dm
+++ b/code/datums/weather/weather_types/rain.dm
@@ -31,6 +31,13 @@
 	var/datum/looping_sound/rain_sounds/sound_ao = new(list(), FALSE, TRUE)
 	var/datum/looping_sound/indoor_rain_sounds/sound_ai = new(list(), FALSE, TRUE)
 
+/datum/weather/rain/eventarea
+	area_types = list(/area/f13/wasteland/event)
+	probability = 0
+	target_trait = ZTRAIT_AWAY
+	weather_duration_lower = 18000
+	weather_duration_upper = 18000
+
 /datum/weather/rain/weather_act(mob/living/L)
 	if(iscarbon(L))
 		var/mob/living/carbon/C = L

--- a/code/modules/fallout/areas/area.dm
+++ b/code/modules/fallout/areas/area.dm
@@ -31,6 +31,9 @@
 	environment = 19
 	grow_chance = 45
 
+/area/f13/wasteland/event
+	name = "Wasteland (Event)"
+
 /area/f13/forest
 	name = "Forest"
 	icon_state = "forest"


### PR DESCRIPTION
Adds a new area and a subtype of rain that can be used specifically for event maps.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Makes it so that I can do more stuff with event maps without affecting the rest of the server, and also provides a sort of base to add event specific areas/weather/etc. in the future.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Yes.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Pre-Merge Checklist
- [x] Your Pull Request contains no breaking changes
- [x] You tested your changes locally, and they work.
- [x] There are no new Runtimes that appear.
- [x] You documented all of your changes.

<!-- Please check these accordingly. -->

## Changelog
:cl:
add: Added a subtype of the wasteland area and a subtype of the rain datum specifically for event maps
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
