### PR TITLE
fixes #211

### DIFF
--- a/code/modules/clothing/masks/miscellaneous.dm
+++ b/code/modules/clothing/masks/miscellaneous.dm
@@ -342,6 +342,7 @@
 /obj/item/clothing/mask/bandana/durathread
 	name = "durathread bandana"
 	desc =  "A bandana made from durathread, you wish it would provide some protection to its wearer, but it's far too thin..."
+	mob_overlay_icon = 'icons/mob/clothing/mask.dmi'
 	icon_state = "banddurathread"
 
 /obj/item/clothing/mask/paper


### PR DESCRIPTION
## About The Pull Request
![image](https://user-images.githubusercontent.com/42501819/135726906-a134d5b1-b01f-4f58-a263-c792ac763c25.png)

correctly assigns the icon path to the durathread bandana

## Why It's Good For The Game

fixes #211 

## Pre-Merge Checklist
- [x] Your Pull Request contains no breaking changes
- [x] You tested your changes locally, and they work.
- [x] There are no new Runtimes that appear.
- [x] You documented all of your changes.

<!-- Please check these accordingly. -->

## Changelog
:cl:
fix: fixes invisible durathread bandana onmob sprite
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
