### PR TITLE
Oasis Armory: Planning for the future

### DIFF
--- a/code/modules/clothing/suits/light_armor.dm
+++ b/code/modules/clothing/suits/light_armor.dm
@@ -65,10 +65,10 @@
 
 /obj/item/clothing/suit/armored/light/vest/flak
 	name = "ancient flak vest"
-	desc = "Poorly maintained, this patched vest will still still stop some bullets, but don't expect any miracles. The polyester does not go well with acid unless you want to be covered in boiling plastic."
+	desc = "Poorly maintained, this patched vest will still still stop some bullets, but don't expect any miracles. The ballistic nylon used in its construction is inferior to kevlar, and very weak to acid, but still quite tough."
 	icon_state = "vest_flak"
 	item_state = "vest_flak"
-	armor = list("melee" = 0, "bullet" = 30, "laser" = 0, "energy" = 0, "bomb" = 15, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = -50)
+	armor = list("melee" = 0, "bullet" = 30, "laser" = 0, "energy" = 0, "bomb" = 40, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = -50)
 
 /obj/item/clothing/suit/armored/light/vest/kevlar
 	name = "kevlar vest"
@@ -292,8 +292,31 @@
 	item_state = "cowboybvest"
 	desc = "Stylish and has discrete lead plates inserted, just in case someone brings a laser to a fistfight."
 	armor = list("melee" = 15, "bullet" = 10, "laser" = 10, "energy" = 5, "bomb" = 0, "bio" = 0, "rad" = 30, "fire" = 0, "acid" = 0)
+	
+//////////
+// Oasis//
+/////////
 
+/obj/item/clothing/suit/armored/light/town
+	name = "town trenchcoat"
+	desc = "A non-descript black trenchcoat."
+	icon_state = "towntrench"
+	item_state = "hostrench"
+	body_parts_covered = CHEST|GROIN|LEGS|ARMS
+	armor = list("melee" = 20, "bullet" = 15, "laser" = 10, "energy" = 10, "bomb" = 15, "bio" = 10, "rad" = 0, "fire" = 20, "acid" = 5)
 
+/obj/item/clothing/suit/armored/light/town/mayor
+	name = "mayor trenchcoat"
+	desc = "A symbol of the mayor's authority (or lack thereof)."
+	armor = list("melee" = 25, "bullet" = 20, "laser" = 10, "energy" = 10, "bomb" = 15, "bio" = 10, "rad" = 0, "fire" = 20, "acid" = 5)
+	
+/obj/item/clothing/suit/armored/light/vest/town
+	name = "flak vest"
+	desc = "A refurbished flak vest, repaired by the Oasis Police Department. The ballistic nylon has a much tougher weave, but it still will not take acid or most high-powered rounds."
+	icon_state = "vest_flak"
+	item_state = "vest_flak"
+	armor = list("melee" = 10, "bullet" = 30, "laser" = 10, "energy" = 0, "bomb" = 40, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = -50)
+	
 ////////////
 // LEGION //
 ////////////

--- a/code/modules/clothing/suits/light_armor.dm
+++ b/code/modules/clothing/suits/light_armor.dm
@@ -68,7 +68,7 @@
 	desc = "Poorly maintained, this patched vest will still still stop some bullets, but don't expect any miracles. The ballistic nylon used in its construction is inferior to kevlar, and very weak to acid, but still quite tough."
 	icon_state = "vest_flak"
 	item_state = "vest_flak"
-	armor = list("melee" = 0, "bullet" = 30, "laser" = 0, "energy" = 0, "bomb" = 40, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = -50)
+	armor = list("melee" = 0, "bullet" = 30, "laser" = 0, "energy" = 0, "bomb" = 15, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = -50)
 
 /obj/item/clothing/suit/armored/light/vest/kevlar
 	name = "kevlar vest"
@@ -293,16 +293,15 @@
 	desc = "Stylish and has discrete lead plates inserted, just in case someone brings a laser to a fistfight."
 	armor = list("melee" = 15, "bullet" = 10, "laser" = 10, "energy" = 5, "bomb" = 0, "bio" = 0, "rad" = 30, "fire" = 0, "acid" = 0)
 	
-//////////
-// Oasis//
-/////////
+////////////////
+// Oasis/Town//
+//////////////
 
 /obj/item/clothing/suit/armored/light/town
 	name = "town trenchcoat"
 	desc = "A non-descript black trenchcoat."
 	icon_state = "towntrench"
 	item_state = "hostrench"
-	body_parts_covered = CHEST|GROIN|LEGS|ARMS
 	armor = list("melee" = 20, "bullet" = 15, "laser" = 10, "energy" = 10, "bomb" = 15, "bio" = 10, "rad" = 0, "fire" = 20, "acid" = 5)
 
 /obj/item/clothing/suit/armored/light/town/mayor
@@ -310,12 +309,12 @@
 	desc = "A symbol of the mayor's authority (or lack thereof)."
 	armor = list("melee" = 25, "bullet" = 20, "laser" = 10, "energy" = 10, "bomb" = 15, "bio" = 10, "rad" = 0, "fire" = 20, "acid" = 5)
 	
-/obj/item/clothing/suit/armored/light/vest/town
-	name = "flak vest"
+/obj/item/clothing/suit/armored/light/town/vest
+	name = "Oasis flak vest"
 	desc = "A refurbished flak vest, repaired by the Oasis Police Department. The ballistic nylon has a much tougher weave, but it still will not take acid or most high-powered rounds."
 	icon_state = "vest_flak"
 	item_state = "vest_flak"
-	armor = list("melee" = 10, "bullet" = 30, "laser" = 10, "energy" = 0, "bomb" = 40, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = -50)
+	armor = list("melee" = 10, "bullet" = 30, "laser" = 10, "energy" = 0, "bomb" = 20, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = -50)
 	
 ////////////
 // LEGION //

--- a/code/modules/clothing/suits/medium_armor.dm
+++ b/code/modules/clothing/suits/medium_armor.dm
@@ -51,6 +51,13 @@
 	item_state = "combat_chestpiece"
 	armor = list("melee" = 20, "bullet" = 20, "laser" = 15, "energy" = 10, "bomb" = 20, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 0)
 
+/obj/item/clothing/suit/armored/medium/steelbib
+	name = "steel breastplate"
+	desc = "a steel breastplate inspired by a pre-war design. It provides some protection against impacts, cuts, and medium-velocity bullets. It's pressed steel construction feels heavy."
+	icon_state = "steel_bib"
+	item_state = "steel_bib"
+	armor = list("melee" = 25, "bullet" = 25, "laser" = 30, "energy" = 10, "bomb" = 5, "bio" = 0, "rad" = 0, "fire" = 20, "acid" = -10)
+	slowdown = 0.11
 
 // Combat armor
 /obj/item/clothing/suit/armored/medium/combat
@@ -371,7 +378,20 @@
 	desc = "A trenchcoat which does a poor job at hiding the full-body combat armor beneath it."
 	icon_state = "towntrench_heavy"
 	armor = list("melee" = 45, "bullet" = 45, "laser" = 35,  "energy" = 40, "bomb" = 30, "bio" = 40, "rad" = 40, "fire" = 50, "acid" = 10)
+	
+/obj/item/clothing/suit/armored/medium/lawcoat/commissioner
+	name = "commissioner's jacket"
+	desc = "A navy-blue jacket with blue shoulder designations, '/OPD/' stitched into one of the chest pockets, and hidden ceramic trauma plates. It has a small compartment for a holdout pistol."
+	icon_state = "warden_alt"
+	item_state = "armor"
+	armor = list("melee" = 40, "bullet" = 60, "laser" = 30,  "energy" = 35, "bomb" = 30, "bio" = 40, "rad" = 40, "fire" = 50, "acid" = 10)
+	pocket_storage_component_path = /datum/component/storage/concrete/pockets/small/holdout
 
+/obj/item/clothing/suit/armored/medium/steelbib/town
+	name = "steel breastplate"
+	desc = "a steel breastplate inspired by a pre-war design, this one was made locally in Oasis. It uses a stronger steel alloy in it's construction, still heavy though"
+	armor = list("melee" = 30, "bullet" = 35, "laser" = 35, "energy" = 15, "bomb" = 10, "bio" = 0, "rad" = 0, "fire" = 20, "acid" = -10)
+	slowdown = 0.11
 
 ///////////////
 // WAYFARERS //


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Oasis is preparing for the Y2K bug by adding samples of their armor to the time capsule

for testing possible Oasis-unique variants for the future possibility of the death of linearmor
also to see different styles for Oasis to make them look different from the rest of the wastes or alternatives to cowboys
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
future proofing some designs so the transition will be easier
so we can balance it ahead of time
codifying alternative fashion sense for oasis, especially once cowboy-den is implemented 
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Pre-Merge Checklist
- [ ] Your Pull Request contains no breaking changes
- [ ] You tested your changes locally, and they work.
- [ ] There are no new Runtimes that appear.
- [ ] You documented all of your changes.

<!-- Please check these accordingly. -->

## Changelog
:cl:
add: oasis-section to light armor
add: oasis-section in medium armor expanded
add: oasis subtypes for flak vest and steel breastplate

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
