### PR TITLE
removes gib from bottlecap mine

### DIFF
--- a/code/modules/fallout/obj/explosives.dm
+++ b/code/modules/fallout/obj/explosives.dm
@@ -16,6 +16,7 @@
 	obj_integrity = 80
 	max_integrity = 80
 	var/state = FALSE
+	layer = 10
 
 /obj/item/bottlecap_mine/attack_self(mob/user as mob)
 	toggle_activate(user)
@@ -41,7 +42,7 @@
 			STOP_PROCESSING(SSobj, src)
 
 /obj/item/bottlecap_mine/proc/boom()
-	explosion(src.loc,1,2,3, flame_range = 6)
+	explosion(src.loc,0,2,3, flame_range = 6)
 
 /obj/item/bottlecap_mine/process()
 	if(state != ACTIVE)


### PR DESCRIPTION
## About The Pull Request

removes bottlecap mine ability to gib

## Why It's Good For The Game

getting gibbed by a mine isn't fun, this keeps the mine strong but not letting it TOTALLY 100% guaranteed ruin someone's round (damage is still enough to crit and delimb).
also forces the layer to 10 so it's above stuff

## Pre-Merge Checklist
- [y] Your Pull Request contains no breaking changes
- [y) You tested your changes locally, and they work.
- [y] There are no new Runtimes that appear.
- [y] You documented all of your changes.

<!-- Please check these accordingly. -->

## Changelog
:cl:
balance: bottlecap mine can't gib now + forces layer to 10
/:cl:
