### PR TITLE
Slows mob decomposition

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -73,7 +73,7 @@
 	if(!(. = ..()))
 		walk(src, 0) //stops walking
 		if(decompose)
-			if(prob(10)) // 10% chance every cycle to decompose
+			if(prob(1)) // 1% chance every cycle to decompose
 				visible_message("<span class='notice'>\The dead body of the [src] decomposes!</span>")
 				gib(FALSE, FALSE, FALSE, TRUE)
 		CHECK_TICK


### PR DESCRIPTION
## About The Pull Request

Adjusts mob decomposition chance from 10% per cycle to 1% per cycle. Originally, this was 0.2%, so this should be a happy medium.

## Why It's Good For The Game

The current mob decomposition time is way too quick. Mobs will frequently decompose before a player is able to actually skin them, sometimes even if one starts skinning right after killing it.

## Pre-Merge Checklist
- [ ] Your Pull Request contains no breaking changes
- [ ] You tested your changes locally, and they work.
- [ ] There are no new Runtimes that appear.
- [ ] You documented all of your changes.

<!-- Please check these accordingly. -->

## Changelog
:cl:
tweak: Changed mob decomposition chance per cycle to 1.0%
/:cl:
