### PR TITLE
fixes obscure bug

### DIFF
--- a/code/game/objects/structures/flora.dm
+++ b/code/game/objects/structures/flora.dm
@@ -511,9 +511,10 @@
 	icon = 'icons/obj/flora/plants.dmi'
 	icon_state = "pondlily_small"
 	desc = "A small lily pad with a single purple lily flower in the middle."
-
+	layer = WALL_OBJ_LAYER //fortuna edit
 /obj/structure/pondlily_big
 	name = "Large lily pad"
 	icon = 'icons/obj/flora/plants.dmi'
 	icon_state = "pondlily_big"
 	desc = "A large lily pad with a single purple lily flower in full bloom that rests in the middle."
+	layer = WALL_OBJ_LAYER //fortuna edit

--- a/code/game/turfs/simulated/water.dm
+++ b/code/game/turfs/simulated/water.dm
@@ -16,15 +16,20 @@
 	clawfootstep = FOOTSTEP_WATER
 	heavyfootstep = FOOTSTEP_WATER
 
-
+	//fortuna edit
 	depth = 1 // Higher numbers indicates deeper water.
+	var/obj/effect/overlay/water/river/top
 
-// Largely ported from citadels HRP branch
+
+// Fortuna edit. Below is Largely ported from citadels HRP branch
 
 /turf/open/water/Initialize()
 	. = ..()
 	update_icon()
 
+/turf/open/water/update_icon()
+	. = ..()
+	top = new /obj/effect/overlay/water/river(src)
 
 /turf/open/water/Entered(atom/movable/AM, atom/oldloc)
 	if(istype(AM, /mob/living))
@@ -77,3 +82,14 @@
 	adjust_fire_stacks(-amount * 5)
 	for(var/atom/movable/AM in contents)
 		AM.water_act(amount)
+
+//water overlays
+/obj/effect/overlay/water/river
+	name = "water"
+	icon = 'icons/effects/effects.dmi'
+	icon_state = "mob_submerged"
+	density = FALSE
+	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
+	layer = ABOVE_MOB_LAYER
+	anchored = TRUE
+	resistance_flags = INDESTRUCTIBLE

--- a/code/modules/fallout/turf/ground.dm
+++ b/code/modules/fallout/turf/ground.dm
@@ -271,7 +271,8 @@
 	barefootstep = FOOTSTEP_WATER
 	clawfootstep = FOOTSTEP_WATER
 	heavyfootstep = FOOTSTEP_WATER
-	
+	var/obj/effect/overlay/water/river/top
+
 /turf/open/indestructible/ground/outside/water/Initialize()
 	. = ..()
 	update_icon()
@@ -297,6 +298,9 @@
 			to_chat(L, "<span class='warning'>You climb out of \the [src].</span>")
 	..()
 
+/turf/open/indestructible/ground/outside/water/update_icon()
+	. = ..()
+	top = new /obj/effect/overlay/water/river(src)
 
 /turf/open/indestructible/ground/outside/snow
 	initial_gas_mix = "o2=22;n2=82;TEMP=285"

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -794,18 +794,12 @@ use_mob_overlay_icon: if FALSE, it will always use the default_icon_file even if
 	update_inv_head()
 	update_inv_wear_mask()
 
+//fortuna edit. for applying effects to players that enter water
 /mob/living/carbon/human/update_water()
 	if(QDESTROYING(src))
 		return
-
-	remove_layer(ABOVE_MOB_LAYER)
-
 	var/depth = check_submerged()
 	if(!depth)
 		return
 	if(lying)
-		overlays_standing[ABOVE_MOB_LAYER] = image(icon = 'icons/effects/effects.dmi', icon_state = "mob_submerged_lying", layer = ABOVE_MOB_LAYER) //TODO: Improve
-	else
-		overlays_standing[ABOVE_MOB_LAYER] = image(icon = 'icons/effects/effects.dmi', icon_state = "mob_submerged", layer = ABOVE_MOB_LAYER) //TODO: Improve
-
-	apply_layer(ABOVE_MOB_LAYER)
+		return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

fixes a bug where if you walk in and out of water for 4 minutes straight you'll keep the water overlay

this removes the water overlay from the mob and keeps it on the turf. it's less pretty imo but it has 0 chance of making you aquaman.

this pr also adjusts the lilypad object layer to be above the new water overlays. overall this uses the same sort of basic turf icon overlay system as upstream does for it's swimming pools, minus the steam.

## Why It's Good For The Game

fixes a very very obscure bug that turns the player into a lord of the sea

## Pre-Merge Checklist
- [x] Your Pull Request contains no breaking changes
- [x] You tested your changes locally, and they work.
- [x] There are no new Runtimes that appear.
- [x] You documented all of your changes.

<!-- Please check these accordingly. -->

## Changelog
:cl:
fix: fixes water overlays
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
