### PR TITLE
infinite v non-infinite spawners

### DIFF
--- a/code/modules/fallout/obj/structures/mob_spawners.dm
+++ b/code/modules/fallout/obj/structures/mob_spawners.dm
@@ -20,6 +20,7 @@
 	var/radius = 10
 	var/spawnsound //specify an audio file to play when a mob emerges from the spawner
 	var/spawn_once
+	var/infinite = FALSE
 
 /obj/structure/nest/Initialize()
 	. = ..()
@@ -52,6 +53,9 @@
 	visible_message("<span class='danger'>[L] [spawn_text] [src].</span>")
 	if(spawnsound)
 		playsound(src, spawnsound, 30, 1)
+	if(!infinite)
+		if(spawned_mobs.len >= max_mobs)
+			Destroy()
 	if(spawn_once) //if the subtype has TRUE, call destroy() after we spawn our first mob
 		Destroy()
 		return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

deletes a spawner by default after it spawns its max_mobs

## Why It's Good For The Game

removes the endless waves

## Pre-Merge Checklist
- [x] Your Pull Request contains no breaking changes
- [x] You tested your changes locally, and they work.
- [x] There are no new Runtimes that appear.
- [x] You documented all of your changes.

<!-- Please check these accordingly. -->

## Changelog
:cl:
tweak: mob spawners now collapse by default after spawning their mobs
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
