### PR TITLE
comments out apc board from autolathe, resolves #106

### DIFF
--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -115,6 +115,7 @@
 	build_path = /obj/item/storage/toolbox
 	category = list("initial","Tools")
 
+/*
 /datum/design/apc_board
 	name = "APC Module"
 	id = "power control"
@@ -123,6 +124,7 @@
 	build_path = /obj/item/electronics/apc
 	category = list("initial", "Electronics")
 	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING
+*/
 
 /datum/design/airlock_board
 	name = "Airlock Electronics"


### PR DESCRIPTION
## About The Pull Request

resolves #106 somewhat, wasters shouldn't have access to a board now so they shouldn't be getting built in the wasteland area

## Why It's Good For The Game

whole wasteland suddenly going powerless is bad

## Pre-Merge Checklist
- [y] Your Pull Request contains no breaking changes
- [ ] You tested your changes locally, and they work.
- [ ] There are no new Runtimes that appear.
- [y] You documented all of your changes.

<!-- Please check these accordingly. -->

## Changelog
:cl:
del: APC board from autolathe
/:cl:
