### PR TITLE
map power solved with 1 if() statement whee

### DIFF
--- a/code/game/objects/items/apc_frame.dm
+++ b/code/game/objects/items/apc_frame.dm
@@ -103,6 +103,14 @@
 	if(!A.requires_power)
 		to_chat(user, "<span class='warning'>You cannot place [src] in this area!</span>")
 		return //can't place apcs in areas with no power requirement
+	/*fortuna edit. 
+	stops our very many duplicated areas from going powerless from one apc placement. 
+	now only the BoS areas need worry about the APCs.
+	TODO: replace the many duplicated areas with unique areas so we dont need this.
+	*/
+	if(A.power_light)
+		to_chat(user, "<span class='warning'>This area already has power!</span>")
+		return
 	for(var/obj/machinery/power/terminal/E in T)
 		if(E.master)
 			to_chat(user, "<span class='warning'>There is another network terminal here!</span>")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

fixes the issue of the map losing power from someone placing an APC in oasis somewhere

## Why It's Good For The Game

this allows the BoS to continue having their APC and manual power, but disallows people from placing APCs in areas that roundstart with power. e.g. all surface areas and more

## Pre-Merge Checklist
- [x] Your Pull Request contains no breaking changes
- [x] You tested your changes locally, and they work.
- [x] There are no new Runtimes that appear.
- [x] You documented all of your changes.

<!-- Please check these accordingly. -->

## Changelog
:cl:
fix: entire map will no longer lose power from any errant apc
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
