### PR TITLE
Disables PAX

### DIFF
--- a/code/modules/reagents/chemistry/recipes/others.dm
+++ b/code/modules/reagents/chemistry/recipes/others.dm
@@ -708,12 +708,6 @@
 	for(var/i in 1 to multiplier)
 		new /obj/item/stack/sheet/plastic(location)
 
-/datum/chemical_reaction/pax
-	name = "pax"
-	id = /datum/reagent/pax
-	results = list(/datum/reagent/pax = 3)
-	required_reagents  = list(/datum/reagent/toxin/mindbreaker = 1, /datum/reagent/medicine/synaptizine = 1, /datum/reagent/water = 1)
-
 // TODO: Add some kind of ghoulification mutation toxin? Iunno.
 
 // Liquid Carpets


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Disables the chemical PAX.

## Why It's Good For The Game

PAX is rather easy to make and unfair to others when used as a chemical weapon. There's very few counter play, and in general is unfair and unfun to play against.

## Pre-Merge Checklist
- [X] Your Pull Request contains no breaking changes
- [X] You tested your changes locally, and they work.
- [X] There are no new Runtimes that appear.
- [X] You documented all of your changes.

<!-- Please check these accordingly. -->

## Changelog
:cl:
del: You can no longer make PAX.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
