### PR TITLE
less annoying, more immersive reactor sounds

### DIFF
--- a/code/modules/power/antimatter/control.dm
+++ b/code/modules/power/antimatter/control.dm
@@ -30,6 +30,7 @@
 
 	var/stored_power = 0//Power to deploy per tick
 	var/datum/looping_sound/supermatter/soundloop //fortuna edit. adds reactor sounds
+
 /obj/machinery/power/am_control_unit/Initialize()
 	. = ..()
 	linked_shielding = list()
@@ -72,15 +73,8 @@
 	return
 
 /obj/machinery/power/am_control_unit/proc/produce_power()
-<<<<<<< Updated upstream
-	if(prob(10))
-		playsound(src.loc, 'sound/machines/sm/loops/calm.ogg', 25, 1)
-||||||| constructed merge base
-	playsound(src.loc, 'sound/effects/bang.ogg', 25, 1)
-=======
 	soundloop.mid_sounds = list('sound/machines/sm/loops/calm.ogg' = 1) //fortuna edit
 	//playsound(src.loc, 'sound/effects/bang.ogg', 25, 1) //fortuna edit
->>>>>>> Stashed changes
 	var/core_power = reported_core_efficiency//Effectively how much fuel we can safely deal with
 	if(core_power <= 0)
 		return 0//Something is wrong
@@ -101,15 +95,9 @@
 		for(var/obj/machinery/am_shielding/AMS in linked_cores)
 			AMS.stability -= core_damage
 			AMS.check_stability(1)
-<<<<<<< Updated upstream
-		if(prob(10))
-			playsound(src.loc, 'sound/machines/sm/loops/calm.ogg', 25, 1)
-	CHECK_TICK
-||||||| constructed merge base
-		playsound(src.loc, 'sound/effects/bang.ogg', 50, 1)
-=======
 		//playsound(src.loc, 'sound/effects/bang.ogg', 50, 1) //fortuna edit
->>>>>>> Stashed changes
+	CHECK_TICK
+
 	return
 
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

bos reactor will now sound like a reactor (specifically supermatter) instead of a null rod while generating power. the sound volume, just like the supermatter engine, will vary based on how much core power there is. what ive seen is that the sound sort of waves in and out from the soundloop, but if you have a damaged reactor with lower core power you'll get lower volume. i'd add in cool functionality like the supermatter has where if it's damaged it makes a different noise, but in playing i've never once seen anyone actually target this thing to try and damage it.

https://user-images.githubusercontent.com/42501819/136644377-92844240-7739-4ea5-b4eb-32c22e7df540.mp4


## Why It's Good For The Game

less annoying, more immersive reactor sounds

## Pre-Merge Checklist
- [x] Your Pull Request contains no breaking changes
- [x] You tested your changes locally, and they work.
- [x] There are no new Runtimes that appear.
- [x] You documented all of your changes.

<!-- Please check these accordingly. -->

## Changelog
:cl:
tweak: BoS reactor now sounds like a reactor
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
