### PR TITLE
Rule 3.7 - Faction Combat

### DIFF
--- a/html/rules.html
+++ b/html/rules.html
@@ -43,6 +43,8 @@ If you have questions, submit an adminhelp (F1) and ask us!<br>
 3.3) Do not utilize exploits, do not share exploits with other players. Report them privately to staff or our development team.<br>
 3.4) Do not mechanically engage with players who are SSD, AFK, or otherwise unresponsive but alive.<br>
 3.5) You may not behead someone without at least one emote describing the action, as well as ample in-character reasoning.<br>
+3.6) Off-duty roles must not act as regular on-duty faction members. Off-duty personnel must defer authority to those on-duty. Do not pull rank when off-duty.<br>
+3.7) Faction members must wear faction armor in combat. They may not discard their faction armor in favor of unaffiliated or generic armor. Painting generic armor in faction colors does not quality it as faction armor.<br>
 <br>
 <br>
 <strong>Rule 4: Escalation and Combat</strong><br>


### PR DESCRIPTION
Adds Rule 3.7:
`3.7) Faction members must wear faction armor in combat. They may not discard their faction armor in favor of unaffiliated or generic armor. Painting generic armor in faction colors does not quality it as faction armor. `

Also updates the rules to show rule 3.6 regarding off-duties, which was previously missing.