### PR TITLE
fish butchering fix and lobster eggs

### DIFF
--- a/code/game/objects/items/fish.dm
+++ b/code/game/objects/items/fish.dm
@@ -120,7 +120,7 @@
 
 /obj/item/fishyegg/lobster
 	name = "lobster fish egg"
-	icon_state = "lobster_eggs"
+	icon_state = "catfish_eggs"
 
 /obj/item/fishyegg/shrimp
 	name = "shrimp fish egg"


### PR DESCRIPTION
## About The Pull Request

makes it so all sharp objects can butcher fish, how regular butchering works
makes lobster eggs item use catfish eggs sprite, lobster eggs sprite didn't exist and catfish eggs look appropriately red
fixes #344 
fixes #343 

## Why It's Good For The Game

this is just a fix, most sharp objects are not pathed as knives and lobster eggs were invisible

## Pre-Merge Checklist
- [x] Your Pull Request contains no breaking changes
- [ ] You tested your changes locally, and they work.
- [ ] There are no new Runtimes that appear.
- [x] You documented all of your changes.

<!-- Please check these accordingly. -->

## Changelog
:cl:
tweak: fish can now be butchered with all sharp objects like regular mobs
fix: lobster eggs sprite
/:cl:
