### PR TITLE
Gives all carbon mobs NO_DECAP, requires you to use a verb on a player to remove it.

### DIFF
--- a/code/game/objects/structures/guillotine.dm
+++ b/code/game/objects/structures/guillotine.dm
@@ -191,10 +191,10 @@
 
 /obj/structure/guillotine/post_buckle_mob(mob/living/M)
 	if (!istype(M, /mob/living/carbon/human))
-		return
-
-	var/mob/living/carbon/human/H = M
-
+		var/mob/living/carbon/human/H = M
+		if(HAS_TRAIT(src, TRAIT_STUNIMMUNE))
+			REMOVE_TRAIT(M, NO_DECAP, "[type]")
+			return
 	if (H.dna)
 		if (H.dna.species)
 			var/datum/species/S = H.dna.species
@@ -216,6 +216,7 @@
 /obj/structure/guillotine/post_unbuckle_mob(mob/living/M)
 	M.regenerate_icons()
 	M.pixel_y -= -GUILLOTINE_HEAD_OFFSET // Move their body back
+	M.add_trait(NO_DECAP)
 	M.layer -= GUILLOTINE_LAYER_DIFF
 	..()
 

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -506,3 +506,48 @@
 	visible_message("<span class='danger'>[attack_message]</span>",\
 		"<span class='userdanger'>[attack_message_local]</span>", null, COMBAT_MESSAGE_RANGE)
 	return TRUE
+	
+// Allows player to activate a verb on a downed character, priming them for a beheading with a Y/N rule prompt.
+
+/mob/living/verb/preparedecap(mob/living/target in (view(1) - usr))
+	set category = "IC"
+	set name = "Prepare Decapitation"
+	var/confirm = alert("Are you sure you wish to prepare this person for decapitation? It will take one minute to do so, and you will then need to cut their head off normally. Decapitations fall under rule 3.5 - You may not behead someone without at least one emote describing the action. Beheading for the sole purpose of preventing revival is prohibited.", "Confirm Decapitation", "Yes", "No")
+	if(confirm == "Yes")
+		log_admin("DECAPITATION: [key_name(usr)] has started preparing to decapitate [target]!.")
+		preparedecap(target)
+
+/mob/living/proc/preparedecap(mob/living/target)
+	if(!incapacitated() && Adjacent(target))
+		if(do_after(user, 600, target = src))
+			REMOVE_TRAIT(target, NO_DECAP, "[type]")
+			log_combat("[src] prepared [target] for decapitation!")
+			user.visible_message("<span class='danger'>[user] is preparing to behead [target]!</span>")
+			target.adjustBruteLoss(40)
+	return
+	else
+		to_chat(src, "<span class='notice'>You cannot prepare this person for decapitation.</span>")
+		return
+		
+/mob/living/verb/decapitate(mob/living/target in (view(1) - usr))
+	set category = "IC"
+	set name = "Decapitate"
+	var/confirm = alert("Are you sure you wish to decapitate this person? It will take one minute to do so. Decapitations fall under rule 3.5 - You may not behead someone without at least one emote describing the action. Beheading for the sole purpose of preventing revival is prohibited.", "Confirm Decapitation", "Yes", "No")
+	if(confirm == "Yes")
+		log_admin("DECAPITATION: [key_name(usr)] has begun to decapitate [target]!")
+		decapitate(target)
+
+/mob/living/proc/decapitate(mob/living/target)
+	if(!incapacitated() && Adjacent(target) && lying(target))
+		user.visible_message("<span class='danger'>[user] is attempting to decapitate [target]!</span>")
+		if(do_after(user, 600, target = src))
+			REMOVE_TRAIT(target, NO_DECAP, "[type]")
+			log_combat("[src] prepared [target] for decapitation!")
+			user.visible_message("<span class='danger'>[user] decapitates [target]! How horrible!</span>")
+			target.adjustBruteLoss(100)
+			head.dismember()
+	return
+	else
+		to_chat(src, "<span class='notice'>You cannot decapitate this person.</span>")
+		return
+

--- a/code/modules/mob/living/carbon/carbon_defines.dm
+++ b/code/modules/mob/living/carbon/carbon_defines.dm
@@ -3,6 +3,7 @@
 	pressure_resistance = 15
 	possible_a_intents = list(INTENT_HELP, INTENT_HARM)
 	hud_possible = list(HEALTH_HUD,STATUS_HUD,ANTAG_HUD,GLAND_HUD,NANITE_HUD,DIAG_NANITE_FULL_HUD,RAD_HUD,ONLINE_HUD)
+	mob_trait = NO_DECAP // This can be removed via a verb.
 	has_limbs = 1
 	held_items = list(null, null)
 	var/list/stomach_contents		= list()
@@ -77,3 +78,4 @@
 
 	/// Timer id of any transformation
 	var/transformation_timer
+

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -73,7 +73,7 @@
 	if(!(. = ..()))
 		walk(src, 0) //stops walking
 		if(decompose)
-			if(prob(10)) // 10% chance every cycle to decompose
+			if(prob(1)) // 1% chance every cycle to decompose
 				visible_message("<span class='notice'>\The dead body of the [src] decomposes!</span>")
 				gib(FALSE, FALSE, FALSE, TRUE)
 		CHECK_TICK

--- a/code/modules/projectiles/guns/ballistic/revolver.dm
+++ b/code/modules/projectiles/guns/ballistic/revolver.dm
@@ -244,7 +244,7 @@
 	icon_state = "m29peace"
 	extra_damage = 15
 	extra_penetration = 0.1
-	fire_delay = 10
+	fire_delay = 7
 	burst_size = 1
 	actions_types = list(/datum/action/item_action/toggle_firemode)
 	can_scope = FALSE
@@ -269,7 +269,7 @@
 			spread = 0
 			extra_damage = 15
 			extra_penetration = 0.1
-			fire_delay = 10
+			fire_delay = 7
 			to_chat(user, "<span class='notice'>You switch to single-shot fire.</span>")
 	update_icon()
 

--- a/html/rules.html
+++ b/html/rules.html
@@ -43,6 +43,8 @@ If you have questions, submit an adminhelp (F1) and ask us!<br>
 3.3) Do not utilize exploits, do not share exploits with other players. Report them privately to staff or our development team.<br>
 3.4) Do not mechanically engage with players who are SSD, AFK, or otherwise unresponsive but alive.<br>
 3.5) You may not behead someone without at least one emote describing the action, as well as ample in-character reasoning.<br>
+3.6) Off-duty roles must not act as regular on-duty faction members. Off-duty personnel must defer authority to those on-duty. Do not pull rank when off-duty.<br>
+3.7) Faction members must wear faction armor in combat. They may not discard their faction armor in favor of unaffiliated or generic armor. Painting generic armor in faction colors does not quality it as faction armor.<br>
 <br>
 <br>
 <strong>Rule 4: Escalation and Combat</strong><br>


### PR DESCRIPTION
## About The Pull Request

All carbon mobs now have NO_DECAP. If you wish to remove it in order to decapitate a player, you must use an IC verb 'Prepare Decapitation' and wait for 1 minute. This verb will give a Yes/No prompt that states the rule regarding decapitation. This will remove NO_DECAP and allow you to cut the head off.

Appropriate changes made to guillotine to remove/re-add the NO_DECAP trait.

This is all logged appropriatedly.

Also removed projectiles being able to decapitate because this is kinda silly.

## Why It's Good For The Game

Because I want to remove the absolute fucking cancer that is head transplantation, and this might be a decent way to discourage decapitation.

## Pre-Merge Checklist
- [ ] Your Pull Request contains no breaking changes
- [ ] You tested your changes locally, and they work.
- [ ] There are no new Runtimes that appear.
- [ ] You documented all of your changes.

<!-- Please check these accordingly. -->

## Changelog
:cl:
add: verb to remove no_decap on target
add: no_decap to all carbon mobs
tweak: guillotine adds/removes the no_decap trait on buckle and unbuckle
tweak: makes it so projectiles cannot dismember the head because this is very silly and makes no sense
/:cl: