### PR TITLE
Peacekeeper fan-the-hammer fire rate nerf

### DIFF
--- a/code/modules/projectiles/guns/ballistic/revolver.dm
+++ b/code/modules/projectiles/guns/ballistic/revolver.dm
@@ -258,10 +258,11 @@
 		if(0)
 			select += 1
 			burst_size = 3 //fan the hammer
-			spread = 15
+			spread = 25
 			extra_damage = 0
 			extra_penetration = 0
 			fire_delay = 6
+			weapon_weight = WEAPON_HEAVY //fan the hammer requires two hands
 			to_chat(user, "<span class='notice'>You prepare to fan the hammer for a rapid burst of shots.</span>")
 		if(1)
 			select = 0
@@ -270,6 +271,7 @@
 			extra_damage = 15
 			extra_penetration = 0.1
 			fire_delay = 7
+			weapon_weight = WEAPON_LIGHT
 			to_chat(user, "<span class='notice'>You switch to single-shot fire.</span>")
 	update_icon()
 


### PR DESCRIPTION
## About The Pull Request

Rebalances the Peacekeeper's fanning to be more  reasonable.

## Why It's Good For The Game

Fire delay of 1 allows you to empty 6 shots of .44 into someone in a split second, entirely unfair. Also, fan-the-hammer should require an empty hand, since that's how it actually works. This is at least a little more fair and will stop the gun from being abused so badly. 

Fanning IRL: https://youtu.be/TMZEkZQQ6hk

## Pre-Merge Checklist
- [x] Your Pull Request contains no breaking changes
- [ ] You tested your changes locally, and they work.
- [ ] There are no new Runtimes that appear.
- [x] You documented all of your changes.

<!-- Please check these accordingly. -->

## Changelog
:cl:
tweak: Peacekeeper fan-the-hammer fire delay changed from 1 to 6 and spread increased to 25.
tweak: Peacekeeper fanning now requires an empty hand.
/:cl:
