### PR TITLE
fixes burst fire

### DIFF
--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -111,14 +111,14 @@
 /obj/item/gun/ballistic/automatic/proc/enable_burst()
 	burst_size = initial(burst_size)
 	if(auto_sear)
-		burst_size = 1 + initial(burst_size)
+		burst_size += initial(burst_size)
 	if(burst_improvement)
-		burst_size = 1 + initial(burst_size)
+		burst_size += initial(burst_size)
 	if(burst_improvement && auto_sear)
-		burst_size = 2 + initial(burst_size)
+		burst_size += 1 + initial(burst_size)
 
 /obj/item/gun/ballistic/automatic/proc/disable_burst()
-	burst_size = 1
+	burst_size = initial(burst_size)
 
 /obj/item/gun/ballistic/automatic/can_shoot()
 	return get_ammo()
@@ -227,6 +227,7 @@
 			recoil = 0.1
 			weapon_weight = WEAPON_HEAVY
 			to_chat(user, "<span class='notice'>You switch to automatic fire.</span>")
+			enable_burst()
 		if(1)
 			select = 0
 			burst_size = 1
@@ -272,6 +273,7 @@
 			recoil = 0.1
 			weapon_weight = WEAPON_HEAVY
 			to_chat(user, "<span class='notice'>You switch to automatic fire.</span>")
+			enable_burst()
 		if(1)
 			select = 0
 			burst_size = 1
@@ -311,6 +313,7 @@
 			recoil = 0.1
 			weapon_weight = WEAPON_HEAVY
 			to_chat(user, "<span class='notice'>You switch to automatic fire.</span>")
+			enable_burst()
 		if(1)
 			select = 0
 			burst_size = 1


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

yeah i couldn't figure out the issue at first until i noticed the math was way off.

## Why It's Good For The Game

corrects the burst fire math to not arbitrarily reduce the number of burst_size with an attachment buff when we don't want it to. 

fixes #342

attaching a burst cam to an automatic will now appropriately add it's burst size variable. so, for instance:
grease gun has an initial burst size of 2.
the old code functioned like this:
no burst cam? fire your preset burst size, for grease gun this has been 2.
burst cam? 1 + [our initial burst size, in the case of grease gun, 2.]
change firemode? burst size is now hard set at 1, despite the attachment; overwriting it's changes

new code functions like this:
no burst cam? default burst size.
burst cam? add the default burst size to itself rather than setting it through an arbitrary equation. for the grease gun this makes 4, as is intended.
change firemode? reset to your initial burst size at the start. easy.

## Pre-Merge Checklist
- [x] Your Pull Request contains no breaking changes
- [x] You tested your changes locally, and they work.
- [x] There are no new Runtimes that appear.
- [x] You documented all of your changes.

<!-- Please check these accordingly. -->

## Changelog
:cl:
fix: fixes burst cams breaking when changing firemodes
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
