### PR TITLE
Update airlock.dm

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -136,7 +136,7 @@
 	if(abandoned)
 		var/outcome = rand(1,100)
 		switch(outcome)
-			if(1 to 9)
+/*			if(1 to 9) // Fortuna removal. No idea why this is a thing, randomly replacing airlocks with walls?
 				var/turf/here = get_turf(src)
 				for(var/turf/closed/T in range(2, src))
 					here.PlaceOnTop(T.type)
@@ -144,7 +144,7 @@
 					return
 				here.PlaceOnTop(/turf/closed/wall)
 				qdel(src)
-				return
+				return */
 			if(9 to 11)
 				lights = FALSE
 				locked = TRUE


### PR DESCRIPTION
## About The Pull Request

Removes that weird thing where abandoned airlocks sometimes get removed and replaced with nearby turfs.

## Why It's Good For The Game

Just kind of weird and unnecessary, plus breaks dungeons in some instances, doors being replaced with indestructible turf.

## Pre-Merge Checklist
- [y] Your Pull Request contains no breaking changes
- [ ] You tested your changes locally, and they work.
- [ ] There are no new Runtimes that appear.
- [y] You documented all of your changes.

<!-- Please check these accordingly. -->

## Changelog
:cl:
del: removed ability for airlocks to turn into nearby turfs by chance
/:cl:
