### PR TITLE
Den Radio Fix

### DIFF
--- a/code/__DEFINES/radio.dm
+++ b/code/__DEFINES/radio.dm
@@ -74,8 +74,8 @@
 #define RADIO_TOKEN_LEGION ":l"
 
 #define RADIO_CHANNEL_KHANS "Khans"
-#define RADIO_KEY_KHANS "k"
-#define RADIO_TOKEN_KHANS ":k"
+#define RADIO_KEY_KHANS "a"
+#define RADIO_TOKEN_KHANS ":a"
 
 #define RADIO_CHANNEL_DEN "Den"
 #define RADIO_KEY_DEN "j"

--- a/code/game/objects/items/devices/radio/encryptionkey.dm
+++ b/code/game/objects/items/devices/radio/encryptionkey.dm
@@ -204,7 +204,7 @@
 
 /obj/item/encryptionkey/headset_khans
 	name = "Khan radio encryption key"
-	desc = "An encryption key for a radio headset.  To access the Khan channel, use :k."
+	desc = "An encryption key for a radio headset.  To access the Khan channel, use :a."
 	icon_state = "cypherkey"
 	channels = list(RADIO_CHANNEL_KHANS = 1)
 

--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -367,7 +367,7 @@ GLOBAL_LIST_INIT(channel_tokens, list(
 
 /obj/item/radio/headset/headset_khans
 	name = "khan radio headset"
-	desc = "This is used by the Khans.\nTo access the Khan channel, use :k."
+	desc = "This is used by the Khans.\nTo access the Khan channel, use :a."
 	icon_state = "syndie_headset"
 	keyslot = new /obj/item/encryptionkey/headset_khans
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->
Was kind of lazy in the Khan radio port, didn't notice that the Khan channel overwrote the Den frequency. Also changed the key used to speak on the Khan channel. Currently the specific key doesn't work, although :h does. It's better than the Den radio being broken outright.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Shit works. That's always good.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Pre-Merge Checklist
- [x] Your Pull Request contains no breaking changes
- [x] You tested your changes locally, and they work.
- [x] There are no new Runtimes that appear.
- [x] You documented all of your changes.

<!-- Please check these accordingly. -->

## Changelog
:cl:
fix: fixed Den radio headset frequency/channel
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
