### PR TITLE
adds art supplies and more painting locations in oasis

### DIFF
--- a/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
@@ -2689,6 +2689,13 @@
 	icon_state = "verticalleftborderleft3"
 	},
 /area/f13/wasteland)
+"biF" = (
+/obj/structure/sign/painting/library{
+	persistence_id = "oasis_bar";
+	pixel_x = 32
+	},
+/turf/open/floor/wood/f13/oak,
+/area/f13/building)
 "bjg" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/crafting,
@@ -5623,18 +5630,12 @@
 	},
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
-"cDy" = (
-/obj/structure/sign/poster/contraband/space_cola{
-	pixel_y = 32
-	},
-/turf/open/floor/wood/f13/oak,
-/area/f13/building)
 "cDz" = (
 /obj/structure/chair/left{
 	dir = 4
 	},
 /obj/structure/sign/painting/library{
-	persistence_id = "oasis_public";
+	persistence_id = "oasis_bar";
 	pixel_y = 32
 	},
 /turf/open/floor/carpet/red,
@@ -7693,7 +7694,8 @@
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
 	},
-/obj/structure/sign/poster/contraband/smoke{
+/obj/structure/sign/painting/library{
+	persistence_id = "oasis_bar";
 	pixel_x = 32
 	},
 /turf/open/floor/wood/f13/oak,
@@ -10592,6 +10594,10 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
+/obj/structure/sign/painting/library{
+	persistence_id = "oasis_bar";
+	pixel_y = 32
+	},
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "ePY" = (
@@ -10831,7 +10837,8 @@
 /turf/open/floor/wood/f13/housewoodbroken2,
 /area/f13/building)
 "eVJ" = (
-/obj/structure/sign/poster/official/cohiba_robusto_ad{
+/obj/structure/sign/painting/library{
+	persistence_id = "oasis_bar";
 	pixel_y = 32
 	},
 /turf/open/floor/wood/f13/oak,
@@ -15547,6 +15554,10 @@
 "gZi" = (
 /obj/item/reagent_containers/food/snacks/grown/pumpkin{
 	pixel_y = 16
+	},
+/obj/structure/sign/painting/library{
+	persistence_id = "oasis_public";
+	pixel_y = 32
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	name = "metal plating"
@@ -23418,6 +23429,15 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/ncr)
+"krf" = (
+/obj/structure/sign/painting/library{
+	persistence_id = "oasis_public";
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	name = "metal plating"
+	},
+/area/f13/building)
 "krk" = (
 /obj/structure/simple_door/metal/ventilation,
 /obj/structure/barricade/wooden/planks/pregame,
@@ -27861,6 +27881,16 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/tier6,
 /turf/open/floor/f13{
 	icon_state = "floordirty"
+	},
+/area/f13/building)
+"mAD" = (
+/obj/structure/fence,
+/obj/structure/sign/painting/library{
+	persistence_id = "oasis_public";
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	name = "metal plating"
 	},
 /area/f13/building)
 "mBd" = (
@@ -35536,6 +35566,15 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/village)
+"qox" = (
+/obj/structure/sign/painting/library{
+	persistence_id = "oasis_bar";
+	pixel_y = 32
+	},
+/turf/open/floor/wood/f13/oak{
+	icon_state = "oakfloor4-broken"
+	},
+/area/f13/building)
 "qoK" = (
 /obj/structure/flora/tree/tall{
 	icon_state = "tree_3";
@@ -78207,7 +78246,7 @@ dCV
 dCV
 kfY
 dCV
-ueA
+krf
 ydO
 ydO
 ydO
@@ -78725,7 +78764,7 @@ kTf
 ydO
 mHj
 kEI
-mZn
+mAD
 mZn
 mZn
 kEI
@@ -85395,7 +85434,7 @@ uqa
 dCV
 mvv
 kEI
-cDy
+eVJ
 cNO
 ozq
 ozq
@@ -86680,7 +86719,7 @@ uqa
 dCV
 bZi
 uqa
-aRl
+eVJ
 ozq
 nJU
 aRl
@@ -87451,7 +87490,7 @@ uqa
 dCV
 mvv
 uqa
-cHk
+qox
 cUZ
 cUZ
 dVy
@@ -87709,9 +87748,9 @@ dCV
 mvv
 gCh
 ozq
-aRl
+biF
 dAn
-ozq
+dAn
 gCh
 mHj
 ydO

--- a/code/modules/WVM/wvm.dm
+++ b/code/modules/WVM/wvm.dm
@@ -789,8 +789,11 @@ GLOBAL_VAR_INIT(vendor_cash, 0)
 		new /datum/data/wasteland_equipment("Glass Sheets x 10",				/obj/item/stack/sheet/glass/ten,									30),
 		new /datum/data/wasteland_equipment("Glass Sheets x 50",				/obj/item/stack/sheet/glass/fifty,									90),
 		new /datum/data/wasteland_equipment("Wood Planks x 50",					/obj/item/stack/sheet/mineral/wood/fifty,							50),
-		new /datum/data/wasteland_equipment("Wood Planks x 20",					/obj/item/stack/sheet/mineral/wood/twenty,							20)
-
+		new /datum/data/wasteland_equipment("Wood Planks x 20",					/obj/item/stack/sheet/mineral/wood/twenty,							20),
+		new /datum/data/wasteland_equipment("Art Canvas 19x19",					/obj/item/canvas/nineteenXnineteen,									20),
+		new /datum/data/wasteland_equipment("Art Canvas 23x19",					/obj/item/canvas/twentythreeXnineteen,								20),
+		new /datum/data/wasteland_equipment("Art Canvas 23x23",					/obj/item/canvas/twentythreeXtwentythree,							20),
+		new /datum/data/wasteland_equipment("Spray Can",						/obj/item/toy/crayon/spraycan,										75)
 		)
 
 /obj/machinery/mineral/wasteland_vendor/mining


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

art supplies are now in the crafting vendor in oasis. the bar paintings in oasis are now bar-specific and the outside paintings around town are outside-specific so there's bar art and public art, as it were.

## Why It's Good For The Game

moar art

## Pre-Merge Checklist
- [x] Your Pull Request contains no breaking changes
- [x] You tested your changes locally, and they work.
- [x] There are no new Runtimes that appear.
- [x] You documented all of your changes.

<!-- Please check these accordingly. -->

## Changelog
:cl:
add: more art supplies in the wasteland crafting vendor and more painting locations
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
