### PR TITLE
Disables placing glass floors

### DIFF
--- a/code/game/turfs/simulated/floor/plating.dm
+++ b/code/game/turfs/simulated/floor/plating.dm
@@ -66,7 +66,7 @@
 					R.use(2)
 					to_chat(user, "<span class='notice'>You reinforce the floor.</span>")
 				return
-	/* Fortuna edit: glass floors
+	/* Fortuna edit: glass floors disabled
 	if(istype(C, /obj/item/stack/sheet/glass))
 		if(broken || burnt)
 			to_chat(user, "<span class='warning'>Repair the plating first!</span>")


### PR DESCRIPTION
## About The Pull Request

Disables creating glass floors.

## Why It's Good For The Game

Glass floors are transparent and make the z-level beneath them visible through the floor. This leads to weird, immersion-breaking results: https://i.imgur.com/RuNVttK.png

## Pre-Merge Checklist
- [x] Your Pull Request contains no breaking changes
- [ ] You tested your changes locally, and they work.
- [ ] There are no new Runtimes that appear.
- [x] You documented all of your changes.

<!-- Please check these accordingly. -->

## Changelog
:cl:
del: Disables placing transparent glass floors.
/:cl: