### PR TITLE
RCW damage nerf

### DIFF
--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -385,7 +385,7 @@
 /obj/item/projectile/beam/laser/rcw //RCW
 	name = "rapidfire beam"
 	icon_state = "xray"
-	damage = 40
+	damage = 30
 	armour_penetration = 0.25
 	impact_effect_type = /obj/effect/temp_visual/impact_effect/green_laser
 	light_color = LIGHT_COLOR_GREEN


### PR DESCRIPTION
## About The Pull Request

Reduces RCW damage from 40 per shot to 30 per shot. AP stays the same at 0.25.

## Why It's Good For The Game

The RCW's raw damage of 40 burn per shot was too powerful given its strong AP and two round burst, giving it 80 damage per burst at 0.25 AP -- enough to melt through most armor and crit people very very quickly. The RCW should be strong, but not THIS strong. 60 raw burn damage per burst is more balanced.

## Pre-Merge Checklist
- [x] Your Pull Request contains no breaking changes
- [ ] You tested your changes locally, and they work.
- [ ] There are no new Runtimes that appear.
- [x] You documented all of your changes.

<!-- Please check these accordingly. -->

## Changelog
:cl:
balance: RCW projectile damage reduced from 40 to 30.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
