### PR TITLE
Gun books for BoS Knights

### DIFF
--- a/code/modules/jobs/job_types/bos.dm
+++ b/code/modules/jobs/job_types/bos.dm
@@ -309,7 +309,7 @@ Head Knight
 		/obj/item/melee/onehanded/knife/hunting = 1,
 		/obj/item/reagent_containers/hypospray/medipen/stimpak = 2,
 		/obj/item/book/granter/crafting_recipe/gunsmith_one=1,
-		/obj/item/book/granter/crafting_recipe/gunsmith_two=1,
+		/obj/item/book/granter/crafting_recipe/gunsmith_two=1
 		)
 
 /datum/outfit/loadout/capstand
@@ -721,7 +721,7 @@ Senior Knight
 		/obj/item/melee/onehanded/knife/hunting=1,
 		/obj/item/reagent_containers/hypospray/medipen/stimpak=2,
 		/obj/item/book/granter/crafting_recipe/gunsmith_one=1,
-		/obj/item/book/granter/crafting_recipe/gunsmith_two=1,
+		/obj/item/book/granter/crafting_recipe/gunsmith_two=1
 		)
 
 /datum/outfit/loadout/sknighta
@@ -804,7 +804,7 @@ Knight
 		/obj/item/melee/onehanded/knife/survival=1,
 		/obj/item/reagent_containers/hypospray/medipen/stimpak=1,
 		/obj/item/book/granter/crafting_recipe/gunsmith_one=1,
-		/obj/item/book/granter/crafting_recipe/gunsmith_two=1,
+		/obj/item/book/granter/crafting_recipe/gunsmith_two=1
 		)
 
 /datum/outfit/loadout/knighta


### PR DESCRIPTION
## About The Pull Request

Adds gunsmithing books 1 and 2 to Knight and Senior/Head Knight. Previously only Initiates got these books, meaning that Knights couldn't make ammo unless they have Knight-Aspirants. 

## Why It's Good For The Game


## Pre-Merge Checklist
- [x] Your Pull Request contains no breaking changes
- [ ] You tested your changes locally, and they work.
- [ ] There are no new Runtimes that appear.
- [x] You documented all of your changes.

<!-- Please check these accordingly. -->

## Changelog
:cl:
add: gunsmithing 1 and 2 for the knight caste
/:cl: