### PR TITLE
Ghost Spawners

### DIFF
--- a/code/game/objects/structures/ghost_role_spawners.dm
+++ b/code/game/objects/structures/ghost_role_spawners.dm
@@ -760,6 +760,9 @@
 		/obj/item/melee/onehanded/knife/bowie = 1,
 		)
 
+/obj/effect/mob_spawn/human/fallout13/ncr/special(mob/living/new_spawn)
+	new_spawn.real_name = random_unique_name(gender)
+
 /obj/effect/mob_spawn/human/fallout13/legion
 	name = "Prime Legionnaire Spawn"
 	desc = "An entry point for prime legionaries of Caesar's Legion to join a battle."
@@ -819,6 +822,9 @@
 		/obj/item/clothing/accessory/bos/paladin=1
 		)
 
+/obj/effect/mob_spawn/human/fallout13/bos/special(mob/living/new_spawn)
+	new_spawn.real_name = random_unique_name(gender)
+
 /obj/effect/mob_spawn/human/fallout13/raider
 	name = "Raider Spawn"
 	desc = "An entry point for raiders to join a battle."
@@ -837,3 +843,6 @@
 	backpack_contents = list(
 		/obj/item/ammo_box/magazine/greasegun = 2,
 		)
+
+/obj/effect/mob_spawn/human/fallout13/raider/special(mob/living/new_spawn)
+	new_spawn.real_name = random_unique_name(gender)


### PR DESCRIPTION
Adds two sets of ghost role spawners for the NCR, Legion and the BoS each. There's also a raider spawner.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
First iteration of F13 ghost role spawners. Would be used for events mainly, to act as way to add player controlled enemies/allies quickly with little work on the admin side. The descriptions and flavor texts for these roles suck, I know. But they work for what I'm going for and don't matter too much. May possibly add more spawners in the future.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Makes spawning ghosts as certain roles easier.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Pre-Merge Checklist
- [x] Your Pull Request contains no breaking changes
- [x] You tested your changes locally, and they work.
- [x] There are no new Runtimes that appear.
- [x] You documented all of your changes.

<!-- Please check these accordingly. -->

## Changelog
:cl:
add: Adds ghost role spawners for the NCR, Legion, and the BoS. There's also a raider spawner
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
