### PR TITLE
what if we sent the reload proc when our chat breaks

### DIFF
--- a/code/modules/tgui_panel/tgui_panel.dm
+++ b/code/modules/tgui_panel/tgui_panel.dm
@@ -61,6 +61,7 @@
 /datum/tgui_panel/proc/on_initialize_timed_out()
 	// Currently does nothing but sending a message to old chat.
 	SEND_TEXT(client, "<span class=\"userdanger\">Failed to load fancy chat, click <a href='?src=[REF(src)];reload_tguipanel=1'>HERE</a> to attempt to reload it.</span>")
+	client.nuke_chat() //maybe maybe maybe
 
 /**
  * private


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

what if we forced the client to reload the chat instead of asking them to haha jk unless..?

## Why It's Good For The Game

maybe fewer instances of having to manually reload the chat

## Pre-Merge Checklist
- [x] Your Pull Request contains no breaking changes
- [x] You tested your changes locally, and they work.
- [x] There are no new Runtimes that appear.
- [x] You documented all of your changes.

<!-- Please check these accordingly. -->

## Changelog
:cl:
tweak: bandaid asset delivery fix
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
