### PR TITLE
Adjusting Raider Ghost Role

### DIFF
--- a/code/_globalvars/lists/poll_ignore.dm
+++ b/code/_globalvars/lists/poll_ignore.dm
@@ -20,6 +20,7 @@
 #define POLL_IGNORE_CLONE "clone"
 #define POLL_IGNORE_CONTRACTOR_SUPPORT "contractor_support"
 #define POLL_IGNORE_FUGITIVE "fugitive"
+#define POLL_IGNORE_RAIDER "raider"
 
 GLOBAL_LIST_INIT(poll_ignore_desc, list(
 	POLL_IGNORE_SENTIENCE_POTION = "Sentience potion",
@@ -40,7 +41,8 @@ GLOBAL_LIST_INIT(poll_ignore_desc, list(
 	POLL_IGNORE_WIZARD = "Wizards",
 	POLL_IGNORE_CLONE = "Defective/SDGF clones",
 	POLL_IGNORE_CONTRACTOR_SUPPORT = "Contractor Support Unit",
-	POLL_IGNORE_FUGITIVE = "Fugitive Hunter"
+	POLL_IGNORE_FUGITIVE = "Fugitive Hunter",
+	POLL_IGNORE_RAIDER = "Raiders"
 ))
 GLOBAL_LIST_INIT(poll_ignore, init_poll_ignore())
 

--- a/code/game/objects/structures/ghost_role_spawners.dm
+++ b/code/game/objects/structures/ghost_role_spawners.dm
@@ -842,7 +842,7 @@
 	shoes = /obj/item/clothing/shoes/jackboots
 	back = /obj/item/storage/backpack/satchel/leather
 	backpack_contents = list(
-		/obj/item/ammo_box/magazine/greasegun = 4,
+		/obj/item/ammo_box/magazine/greasegun = 2,
 		/obj/item/reagent_containers/hypospray/medipen/stimpak = 2,
 		)
 

--- a/code/game/objects/structures/ghost_role_spawners.dm
+++ b/code/game/objects/structures/ghost_role_spawners.dm
@@ -837,12 +837,15 @@
 	uniform = /obj/item/clothing/under/f13/ravenharness
 	suit = /obj/item/clothing/suit/armor/f13/combat/mk2/raider
 	head = /obj/item/clothing/head/helmet/f13/combat/mk2/raider
+	ears = /obj/item/radio/headset
 	belt = /obj/item/storage/belt/military/assault
 	shoes = /obj/item/clothing/shoes/jackboots
 	back = /obj/item/storage/backpack/satchel/leather
 	backpack_contents = list(
-		/obj/item/ammo_box/magazine/greasegun = 2,
+		/obj/item/ammo_box/magazine/greasegun = 4,
+		/obj/item/reagent_containers/hypospray/medipen/stimpak = 2,
 		)
 
 /obj/effect/mob_spawn/human/fallout13/raider/special(mob/living/new_spawn)
 	new_spawn.real_name = random_unique_name(gender)
+	to_chat(new_spawn, "<span class='userdanger'>You are a raider, therefore, an antagonist! You must maintain immersion and roleplay according. Remember, you are still beholden to escalation rules!</span>")

--- a/code/game/objects/structures/ghost_role_spawners.dm
+++ b/code/game/objects/structures/ghost_role_spawners.dm
@@ -849,3 +849,9 @@
 /obj/effect/mob_spawn/human/fallout13/raider/special(mob/living/new_spawn)
 	new_spawn.real_name = random_unique_name(gender)
 	to_chat(new_spawn, "<span class='userdanger'>You are a raider, therefore, an antagonist! You must maintain immersion and roleplay according. Remember, you are still beholden to escalation rules!</span>")
+
+/obj/effect/mob_spawn/human/fallout13/raider/Initialize(mapload)
+	. = ..()
+	var/area/A = get_area(src)
+	if(A)
+		notify_ghosts("A small gang of raiders are arriving at \the [A.name].", source = src, action=NOTIFY_ATTACK, flashwindow = FALSE, ignore_key = POLL_IGNORE_RAIDER, ignore_dnr_observers = FALSE)

--- a/code/modules/mob/living/carbon/human/species_types/zombies.dm
+++ b/code/modules/mob/living/carbon/human/species_types/zombies.dm
@@ -105,7 +105,6 @@
 	mutanthands = /obj/item/ghoul_zombie_hand
 	brutemod = 0.5
 	burnmod = 0.5
-	armor = 50
 
 /datum/species/zombie/infectious/ghoul/on_species_gain(mob/living/carbon/C, datum/species/old_species)
 	..()

--- a/code/modules/mob/living/carbon/human/species_types/zombies.dm
+++ b/code/modules/mob/living/carbon/human/species_types/zombies.dm
@@ -101,6 +101,7 @@
 	id = "ghoulzombies"
 	limbs_id = "ghoul"
 	say_mod = "rasps"
+	inherent_traits = list(TRAIT_NODECAP, TRAIT_NIGHT_VISION)
 	mutanthands = /obj/item/ghoul_zombie_hand
 	brutemod = 0.5
 	burnmod = 0.5

--- a/code/modules/mob/living/simple_animal/hostile/f13/supermutant.dm
+++ b/code/modules/mob/living/simple_animal/hostile/f13/supermutant.dm
@@ -285,7 +285,7 @@
 	speak = list("The rain speaks through me!", "Witness the gifts of rain!", "The great flood will come upon us! Do not fear it!", "My life for the rain gods!", "The rain gods can always use more sacrifices!")
 	maxHealth = 450
 	health = 450
-	damage_coeff = list(BRUTE = -0.5, BURN = 0.75, TOX = 0, CLONE = 0, STAMINA = 0, OXY = 0)
+	damage_coeff = list(BRUTE = -0.1, BURN = 1, TOX = 0, CLONE = 0, STAMINA = 0, OXY = 0)
 	melee_damage_lower = 60
 	melee_damage_upper = 70
 	var/charging = FALSE
@@ -376,7 +376,7 @@
 	speak = list("The rain speaks through me!", "Witness the gifts of rain!", "The great flood will come upon us! Do not fear it!", "My life for the rain gods!", "The rain gods can always use more sacrifices!")
 	maxHealth = 450
 	health = 450
-	damage_coeff = list(BRUTE = 0.75, BURN = -0.5, TOX = 0, CLONE = 0, STAMINA = 0, OXY = 0)
+	damage_coeff = list(BRUTE = 1, BURN = -0.25, TOX = 0, CLONE = 0, STAMINA = 0, OXY = 0)
 	melee_damage_lower = 60
 	melee_damage_upper = 70
 	extra_projectiles = 2

--- a/code/modules/research/designs/autolathe_desings/autolathe_designs_tcomms_and_misc.dm
+++ b/code/modules/research/designs/autolathe_desings/autolathe_designs_tcomms_and_misc.dm
@@ -21,13 +21,14 @@
 	build_path = /obj/item/radio/headset
 	category = list("initial", "T-Comm")
 
-/datum/design/bounced_radio
+/*/datum/design/bounced_radio
 	name = "Station Bounced Radio"
 	id = "bounced_radio"
 	build_type = AUTOLATHE
 	materials = list(/datum/material/iron = 75, /datum/material/glass = 25)
 	build_path = /obj/item/radio/off
 	category = list("initial", "T-Comm")
+*/
 
 /datum/design/intercom_frame
 	name = "Intercom Frame"

--- a/code/modules/research/designs/autolathe_desings/autolathe_designs_tcomms_and_misc.dm
+++ b/code/modules/research/designs/autolathe_desings/autolathe_designs_tcomms_and_misc.dm
@@ -21,14 +21,13 @@
 	build_path = /obj/item/radio/headset
 	category = list("initial", "T-Comm")
 
-/*/datum/design/bounced_radio
+/datum/design/bounced_radio
 	name = "Station Bounced Radio"
 	id = "bounced_radio"
 	build_type = AUTOLATHE
 	materials = list(/datum/material/iron = 75, /datum/material/glass = 25)
 	build_path = /obj/item/radio/off
 	category = list("initial", "T-Comm")
-*/
 
 /datum/design/intercom_frame
 	name = "Intercom Frame"


### PR DESCRIPTION
I'm seeing the value in adding the raider ghost role as a sort of antag to spice things up. I must see how players interact with this role to know how to move forward with it.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Will be doing some experiments in the coming days to see how players use the roles/react to them.
Also changed some of the damage coefficient on the priest CoR mobs. I decided to put it in this PR as it's not really a big change.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Ghost roles may actually bring some value to the game, might as well make them somewhat wortwhile.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Pre-Merge Checklist
- [x] Your Pull Request contains no breaking changes
- [x] You tested your changes locally, and they work.
- [x] There are no new Runtimes that appear.
- [x] You documented all of your changes.

<!-- Please check these accordingly. -->

## Changelog
:cl:
tweak: Added two extra grease gun mags, two stims, and a headset to the raider ghost role
tweak: changes some of the damage coefficient values on two CoR mobs
tweak: Adds a couple traits to a halloween event species
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
