### PR TITLE
adds fermichem stimpaks

### DIFF
--- a/code/datums/components/crafting/recipes/recipes_medicine.dm
+++ b/code/datums/components/crafting/recipes/recipes_medicine.dm
@@ -135,6 +135,7 @@
 				/obj/item/stack/sheet/leather = 2,
 				/obj/item/reagent_containers/food/snacks/grown/mutfruit = 2)
 	tools = list(TOOL_WORKBENCH)
+	blacklist = list(/obj/item/reagent_containers/hypospray/medipen/stimpak/imitation)
 	time = 50
 	category = CAT_MEDICAL
 	blacklist = list(/obj/item/reagent_containers/hypospray/medipen/stimpak/super,
@@ -147,6 +148,7 @@
 				/obj/item/stack/sheet/leather = 10,
 				/obj/item/reagent_containers/food/snacks/grown/mutfruit = 10)
 	tools = list(TOOL_WORKBENCH)
+	blacklist = list(/obj/item/reagent_containers/hypospray/medipen/stimpak/imitation)
 	time = 60
 	category = CAT_MEDICAL
 	blacklist = list(/obj/item/reagent_containers/hypospray/medipen/stimpak/super,

--- a/code/datums/components/crafting/recipes/recipes_medicine.dm
+++ b/code/datums/components/crafting/recipes/recipes_medicine.dm
@@ -92,9 +92,9 @@
 	time = 50
 	category = CAT_MEDICAL
 
-/datum/crafting_recipe/stimpak
-	name = "Stimpak"
-	result = /obj/item/reagent_containers/hypospray/medipen/stimpak
+/datum/crafting_recipe/improvisedstimpak
+	name = "Imitation Stimpak"
+	result = /obj/item/reagent_containers/hypospray/medipen/stimpak/imitation
 	reqs = list(/obj/item/reagent_containers/food/snacks/grown/broc = 4,
 				/obj/item/reagent_containers/food/snacks/grown/xander = 4,
 				/obj/item/reagent_containers/syringe = 1)
@@ -102,9 +102,25 @@
 	time = 45
 	category = CAT_MEDICAL
 
+/datum/crafting_recipe/stimpak
+	name = "Stimpak"
+	result = /obj/item/reagent_containers/hypospray/medipen/stimpak
+	reqs = list(/datum/reagent/medicine/stimpak = 10,
+				/obj/item/reagent_containers/syringe = 1)
+	time = 1 //you're just filling a hypospray with stim fluid... 
+	category = CAT_MEDICAL
+
 /datum/crafting_recipe/stimpak5
 	name = "Stimpak (x5)"
 	result = /obj/item/storage/box/medicine/stimpaks/stimpaks5
+	reqs = list(/datum/reagent/medicine/stimpak = 50,
+				/obj/item/reagent_containers/syringe = 5)
+	time = 5 //you're just filling 5 hypospray with stim fluid... 
+	category = CAT_MEDICAL
+
+/datum/crafting_recipe/improvisedstimpak5
+	name = "Imitation Stimpak (x5)"
+	result = /obj/item/storage/box/medicine/stimpaks/stimpaks5/imitation
 	reqs = list(/obj/item/reagent_containers/food/snacks/grown/broc = 20,
 				/obj/item/reagent_containers/food/snacks/grown/xander = 20,
 				/obj/item/reagent_containers/syringe = 5)

--- a/code/game/objects/items/storage/f13storage.dm
+++ b/code/game/objects/items/storage/f13storage.dm
@@ -429,6 +429,15 @@
 	for(var/i in 1 to 5)
 		new /obj/item/reagent_containers/hypospray/medipen/stimpak(src)
 
+/obj/item/storage/box/medicine/stimpaks/stimpaks5/imitation
+	name = "box of imitation stimpaks"
+	desc = "Mmm. Delicious flower juice."
+	illustration = "syringe"
+
+/obj/item/storage/box/medicine/stimpaks/stimpaks5/PopulateContents()
+	for(var/i in 1 to 5)
+		new /obj/item/reagent_containers/hypospray/medipen/stimpak/imitation(src)
+
 /obj/item/storage/box/medicine/stimpaks/superstimpaks5
 	name = "box of super stimpaks"
 	desc = "A box full of super stimpaks."

--- a/code/modules/fallout/reagents/medicines.dm
+++ b/code/modules/fallout/reagents/medicines.dm
@@ -58,7 +58,7 @@
 	description = "Rapidly heals damage when injected. A poor man's stimpak."
 	reagent_state = LIQUID
 
-/datum/reagent/medicine/stimpak/on_mob_life(mob/living/carbon/M)
+/datum/reagent/medicine/stimpak/imitation/on_mob_life(mob/living/carbon/M)
 	if(M.getBruteLoss() == 0 && M.getFireLoss() == 0)
 		metabolization_rate = 1000 * REAGENTS_METABOLISM //instant metabolise if it won't help you, prevents prehealing before combat
 	M.adjustBruteLoss(-2.5*REAGENTS_EFFECT_MULTIPLIER)

--- a/code/modules/fallout/reagents/medicines.dm
+++ b/code/modules/fallout/reagents/medicines.dm
@@ -53,6 +53,20 @@
 	..()
 	. = TRUE
 
+/datum/reagent/medicine/stimpak/imitation
+	name = "Imitation Stimpak Fluid"
+	description = "Rapidly heals damage when injected. A poor man's stimpak."
+	reagent_state = LIQUID
+
+/datum/reagent/medicine/stimpak/on_mob_life(mob/living/carbon/M)
+	if(M.getBruteLoss() == 0 && M.getFireLoss() == 0)
+		metabolization_rate = 1000 * REAGENTS_METABOLISM //instant metabolise if it won't help you, prevents prehealing before combat
+	M.adjustBruteLoss(-2.5*REAGENTS_EFFECT_MULTIPLIER)
+	M.adjustFireLoss(-2.5*REAGENTS_EFFECT_MULTIPLIER)
+	M.AdjustKnockdown(-5*REAGENTS_EFFECT_MULTIPLIER, 0)
+	M.adjustStaminaLoss(-2*REAGENTS_EFFECT_MULTIPLIER)
+	..()
+
 /datum/reagent/medicine/stimpak/super_stimpak
 	name = "super stim chemicals"
 
@@ -203,7 +217,7 @@ datum/reagent/medicine/stimpak/super_stimpak/on_mob_life(mob/living/M)
 	metabolization_rate = 0.5 * REAGENTS_METABOLISM //in between powder/stimpaks and poultice/superstims?
 	overdose_threshold = 31
 	var/heal_factor = -3 //Subtractive multiplier if you do not have the perk.
-	var/heal_factor_perk = -8 //Multiplier if you have the right perk.
+	var/heal_factor_perk = -5 //Multiplier if you have the right perk.
 
 /datum/reagent/medicine/bitter_drink/on_mob_life(mob/living/carbon/M)
 	var/is_tribal = FALSE
@@ -235,7 +249,7 @@ datum/reagent/medicine/stimpak/super_stimpak/on_mob_life(mob/living/M)
 	metabolization_rate = 0.5 * REAGENTS_METABOLISM
 	overdose_threshold = 30
 	var/heal_factor = -1.5 //Subtractive multiplier if you do not have the perk.
-	var/heal_factor_perk = -3 //Multiplier if you have the right perk.
+	var/heal_factor_perk = -2.5 //Multiplier if you have the right perk.
 
 /datum/reagent/medicine/healing_powder/on_mob_life(mob/living/carbon/M)
 	var/is_tribal = FALSE

--- a/code/modules/food_and_drinks/food/snacks_cake.dm
+++ b/code/modules/food_and_drinks/food/snacks_cake.dm
@@ -328,7 +328,7 @@ obj/item/reagent_containers/food/snacks/store/cake/pound_cake
 
 /obj/item/reagent_containers/food/snacks/store/cake/hardware_cake
 	name = "hardware cake"
-	desc = "A cake that is made with electronic boards and leaks acid..."
+	desc = "The Brotherhood are going to be SO mad."
 	icon_state = "hardware_cake"
 	slice_path = /obj/item/reagent_containers/food/snacks/cakeslice/hardware_cake_slice
 	bonus_reagents = list(/datum/reagent/toxin/acid = 15, /datum/reagent/oil = 15)

--- a/code/modules/food_and_drinks/food/snacks_frozen.dm
+++ b/code/modules/food_and_drinks/food/snacks_frozen.dm
@@ -191,19 +191,19 @@
 	tastes = list("ice" = 1, "water" = 1, "pineapples" = 5)
 	foodtype = PINEAPPLE //Pineapple to allow all that like pineapple to enjoy
 
-/obj/item/reagent_containers/food/snacks/snowcones/soda
-	name = "space cola snowcone"
-	desc = "Space Cola drizzled over a snowball in a paper cup."
+/obj/item/reagent_containers/food/snacks/snowcones/nuka
+	name = "Nuka Cola snowcone"
+	desc = "America's favorite, cold at last. Drizzled over a snowball in a paper cup."
 	icon_state = "soda_sc"
-	list_reagents = list(/datum/reagent/consumable/nutriment = 1, /datum/reagent/consumable/space_cola = 5)
-	tastes = list("ice" = 1, "water" = 1, "cola" = 5)
+	list_reagents = list(/datum/reagent/consumable/nutriment = 1, /datum/reagent/consumable/nuka_cola = 5,  /datum/reagent/radium = 5)
+	tastes = list("ice" = 1, "water" = 1, "nuka cola" = 5)
 
-/obj/item/reagent_containers/food/snacks/snowcones/spacemountainwind
-	name = "\improper Space Mountain Wind snowcone"
-	desc = "Space Mountain Wind drizzled over a snowball in a paper cup."
+/obj/item/reagent_containers/food/snacks/snowcones/sunset
+	name = "\improper Sunset Sasparilla snowcone"
+	desc = "Sunset Sasparilla drizzled over a snowball in a paper cup."
 	icon_state = "kiwi_sc"
-	list_reagents = list(/datum/reagent/consumable/nutriment = 1, /datum/reagent/consumable/spacemountainwind = 5)
-	tastes = list("ice" = 1, "water" = 1, "mountain wind" = 5)
+	list_reagents = list(/datum/reagent/consumable/nutriment = 1, /datum/reagent/consumable/sunset = 5)
+	tastes = list("ice" = 1, "water" = 1, "root beer, vanilla, and caramel" = 5)
 
 /obj/item/reagent_containers/food/snacks/snowcones/pwrgame
 	name = "pwrgame snowcone"

--- a/code/modules/food_and_drinks/food/snacks_pie.dm
+++ b/code/modules/food_and_drinks/food/snacks_pie.dm
@@ -98,7 +98,7 @@
 
 /obj/item/reagent_containers/food/snacks/pie/bearypie
 	name = "beary pie"
-	desc = "No brown bears, this is a good sign."
+	desc = "Was the pun really worth killing a Yao Guai over?"
 	icon_state = "bearypie"
 	bonus_reagents = list(/datum/reagent/consumable/nutriment = 2, /datum/reagent/consumable/nutriment/vitamin = 3)
 	list_reagents = list(/datum/reagent/consumable/nutriment = 2, /datum/reagent/consumable/nutriment/vitamin = 3)

--- a/code/modules/food_and_drinks/food/snacks_salad.dm
+++ b/code/modules/food_and_drinks/food/snacks_salad.dm
@@ -15,7 +15,7 @@
 
 /obj/item/reagent_containers/food/snacks/salad/aesirsalad
 	name = "\improper Aesir salad"
-	desc = "Probably too incredible for mortal men to fully enjoy."
+	desc = "Very rarely eaten by Caesar's Legion when nobody is around to comment on the terrible pun."
 	icon_state = "aesirsalad"
 	bonus_reagents = list(/datum/reagent/medicine/omnizine = 2, /datum/reagent/consumable/nutriment/vitamin = 6)
 	list_reagents = list(/datum/reagent/consumable/nutriment = 8, /datum/reagent/medicine/omnizine = 8, /datum/reagent/consumable/nutriment/vitamin = 6)

--- a/code/modules/food_and_drinks/recipes/tablecraft/recipes_bread.dm
+++ b/code/modules/food_and_drinks/recipes/tablecraft/recipes_bread.dm
@@ -22,7 +22,7 @@
 	)
 	result = /obj/item/reagent_containers/food/snacks/store/bread/meat
 	subcategory = CAT_BREAD
-/*
+
 /datum/crafting_recipe/food/banananutbread
 	name = "Banana nut bread"
 	reqs = list(
@@ -44,6 +44,7 @@
 	result = /obj/item/reagent_containers/food/snacks/store/bread/spidermeat
 	subcategory = CAT_BREAD
 	
+/*
 /datum/crafting_recipe/food/xenomeatbread
 	name = "Xenomeat bread"
 	reqs = list(
@@ -62,7 +63,7 @@
 	)
 	result = /obj/item/reagent_containers/food/snacks/jelliedtoast/slime
 	subcategory = CAT_BREAD
-
+*/
 /datum/crafting_recipe/food/butterdog
 	name = "Butterdog"
 	reqs = list(
@@ -80,7 +81,6 @@
 	)
 	result = /obj/item/reagent_containers/food/snacks/twobread
 	subcategory = CAT_BREAD
-*/
 
 /datum/crafting_recipe/food/tofubread
 	name = "Tofu bread"

--- a/code/modules/food_and_drinks/recipes/tablecraft/recipes_burger.dm
+++ b/code/modules/food_and_drinks/recipes/tablecraft/recipes_burger.dm
@@ -151,7 +151,6 @@
 	result = /obj/item/reagent_containers/food/snacks/pizza/vegetable
 	subcategory = CAT_BURGER
 
-/*
 /datum/crafting_recipe/food/superbiteburger
 	name = "Super bite burger"
 	reqs = list(
@@ -234,7 +233,7 @@
 	)
 	result = /obj/item/reagent_containers/food/snacks/burger/crab
 	subcategory = CAT_BURGER
-
+/*
 /datum/crafting_recipe/food/empoweredburger
 	name = "Empowered Burger"
 	reqs = list(
@@ -243,7 +242,7 @@
 	)
 	result = /obj/item/reagent_containers/food/snacks/burger/empoweredburger
 	subcategory = CAT_BURGER
-
+*/
 /datum/crafting_recipe/food/fivealarmburger
 	name = "Five alarm burger"
 	reqs = list(
@@ -271,7 +270,7 @@
 	)
 	result = /obj/item/reagent_containers/food/snacks/burger/jelly/cherry
 	subcategory = CAT_BURGER
-
+/*
 /datum/crafting_recipe/food/xenoburger
 	name = "Xeno burger"
 	reqs = list(
@@ -309,7 +308,7 @@
 	)
 	result = /obj/item/reagent_containers/food/snacks/burger/spell
 	subcategory = CAT_BURGER
-
+*/
 ////////////COLORED BURGERS//////////////
 
 /datum/crafting_recipe/food/redburger
@@ -391,6 +390,3 @@
 	)
 	result = /obj/item/reagent_containers/food/snacks/burger/white
 	subcategory = CAT_BURGER
-
-
-*/

--- a/code/modules/food_and_drinks/recipes/tablecraft/recipes_cake.dm
+++ b/code/modules/food_and_drinks/recipes/tablecraft/recipes_cake.dm
@@ -1,7 +1,6 @@
 
 
 /////////////SPECIAL////////////
-/*
 /datum/crafting_recipe/food/holycake
 	name = "Angel food cake"
 	reqs = list(
@@ -49,7 +48,7 @@
 	)
 	result = /obj/item/reagent_containers/food/snacks/store/cake/slimecake
 	subcategory = CAT_CAKE
-
+/*
 /datum/crafting_recipe/food/trumpetcake
 	name = "Spaceman's Cake"
 	reqs = list(

--- a/code/modules/food_and_drinks/recipes/tablecraft/recipes_frozen.dm
+++ b/code/modules/food_and_drinks/recipes/tablecraft/recipes_frozen.dm
@@ -23,9 +23,7 @@
 	)
 	result = /obj/item/reagent_containers/food/snacks/icecreamsandwich
 	subcategory = CAT_ICE
-
-/* clownish or branded drink products (pwrgame, cola, soda etc.) are commented out
-
+/*
 /datum/crafting_recipe/food/honkdae
 	name ="Honkdae"
 	reqs = list(
@@ -36,6 +34,7 @@
 		/obj/item/reagent_containers/food/snacks/icecream = 1
 	)
 	result = /obj/item/reagent_containers/food/snacks/honkdae
+*/
 /datum/crafting_recipe/food/icecreamsandwich
 	name = "Icecream sandwich"
 	reqs = list(
@@ -48,10 +47,10 @@
 	subcategory = CAT_ICE
 
 /datum/crafting_recipe/food/spacefreezy
-	name ="Space Freezy"
+	name ="Nuka Freezy"
 	reqs = list(
 		/datum/reagent/consumable/bluecherryjelly = 5,
-		/datum/reagent/consumable/spacemountainwind = 15,
+		/datum/reagent/consumable/nuka_cola = 15,
 		/obj/item/reagent_containers/food/snacks/icecream = 1
 	)
 	result = /obj/item/reagent_containers/food/snacks/spacefreezy
@@ -63,12 +62,11 @@
 	reqs = list(
 		/obj/item/reagent_containers/food/snacks/icecream = 1,
 		/obj/item/reagent_containers/food/snacks/grown/cherries = 1,
-		/datum/reagent/consumable/space_cola = 10,
+		/datum/reagent/consumable/nuka_cola = 10,
 		/obj/item/reagent_containers/food/drinks/drinkingglass = 1
 	)
 	result = /obj/item/reagent_containers/food/snacks/cola_float
 	subcategory = CAT_ICE
-*/
 
 //////////////////////////SNOW CONES///////////////////////
 
@@ -204,7 +202,7 @@
 	)
 	result = /obj/item/reagent_containers/food/snacks/snowcones/pwrgame
 	subcategory = CAT_ICE
-
+*/
 /datum/crafting_recipe/food/rainbow_sc
 	name = "Rainbow snowcone"
 	reqs = list(
@@ -216,22 +214,21 @@
 	subcategory = CAT_ICE
 
 /datum/crafting_recipe/food/soda_sc
-	name = "Space Cola snowcone"
+	name = "Nuka Cola snowcone"
 	reqs = list(
 		/obj/item/reagent_containers/food/drinks/sillycup = 1,
 		/datum/reagent/consumable/ice = 15,
-		/datum/reagent/consumable/space_cola = 5
+		/datum/reagent/consumable/nuka_cola = 5
 	)
-	result = /obj/item/reagent_containers/food/snacks/snowcones/soda
+	result = /obj/item/reagent_containers/food/snacks/snowcones/nuka
 	subcategory = CAT_ICE
 
 /datum/crafting_recipe/food/spacemountainwind_sc
-	name = "Space Mountain Wind snowcone"
+	name = "Sunset Sasparilla snowcone"
 	reqs = list(
 		/obj/item/reagent_containers/food/drinks/sillycup = 1,
 		/datum/reagent/consumable/ice = 15,
-		/datum/reagent/consumable/spacemountainwind = 5
+		/datum/reagent/consumable/sunset = 5
 	)
-	result = /obj/item/reagent_containers/food/snacks/snowcones/spacemountainwind
+	result = /obj/item/reagent_containers/food/snacks/snowcones/sunset
 	subcategory = CAT_ICE
-*/

--- a/code/modules/food_and_drinks/recipes/tablecraft/recipes_pastry.dm
+++ b/code/modules/food_and_drinks/recipes/tablecraft/recipes_pastry.dm
@@ -1,7 +1,6 @@
 // see code/module/crafting/table.dm
 
 ////////////////////////////////////////////////MUFFINS////////////////////////////////////////////////
-/*
 /datum/crafting_recipe/food/muffin
 	time = 15
 	name = "Muffin"
@@ -174,4 +173,3 @@
 	)
 	result = /obj/item/reagent_containers/food/snacks/plumphelmetbiscuit
 	subcategory = CAT_PASTRY
-*/

--- a/code/modules/food_and_drinks/recipes/tablecraft/recipes_pie.dm
+++ b/code/modules/food_and_drinks/recipes/tablecraft/recipes_pie.dm
@@ -170,7 +170,6 @@
 	result = /obj/item/reagent_containers/food/snacks/pie/frostypie
 	subcategory = CAT_PASTRY
 
-/*
 /datum/crafting_recipe/food/goldenappletart
 	name = "Golden apple tart"
 	reqs = list(
@@ -182,7 +181,7 @@
 	result = /obj/item/reagent_containers/food/snacks/pie/appletart
 	subcategory = CAT_PIE
 
-	/datum/crafting_recipe/food/bearypie
+/datum/crafting_recipe/food/bearypie
 	name = "Beary Pie"
 	reqs = list(
 		/obj/item/reagent_containers/food/snacks/pie/plain = 1,
@@ -200,4 +199,16 @@
 	)
 	result = /obj/item/reagent_containers/food/snacks/pie/amanita_pie
 	subcategory = CAT_PIE
-*/
+
+/datum/crafting_recipe/food/cocolavatart
+	name = "Chocolate Lava tart"
+	always_availible = FALSE
+	reqs = list(
+			/datum/reagent/consumable/milk = 5,
+			/datum/reagent/consumable/sugar = 5,
+			/obj/item/reagent_containers/food/snacks/pie/plain = 1,
+			/obj/item/reagent_containers/food/snacks/chocolatebar = 3,
+			/obj/item/slime_extract = 1
+			)
+	result = /obj/item/reagent_containers/food/snacks/pie/cocolavatart
+	subcategory = CAT_PIE

--- a/code/modules/food_and_drinks/recipes/tablecraft/recipes_salad.dm
+++ b/code/modules/food_and_drinks/recipes/tablecraft/recipes_salad.dm
@@ -71,7 +71,7 @@
 	)
 	result = /obj/item/reagent_containers/food/snacks/salad/edensalad
 	subcategory = CAT_MISCFOOD
-/*
+
 /datum/crafting_recipe/food/aesirsalad
 	name = "Aesir salad"
 	reqs = list(
@@ -82,7 +82,7 @@
 	result = /obj/item/reagent_containers/food/snacks/salad/aesirsalad
 	subcategory = CAT_SALAD
 
-
+/*
 /datum/crafting_recipe/food/monkeysdelight
 	name = "Monkeys delight"
 	reqs = list(

--- a/code/modules/food_and_drinks/recipes/tablecraft/recipes_soup.dm
+++ b/code/modules/food_and_drinks/recipes/tablecraft/recipes_soup.dm
@@ -203,7 +203,7 @@
 	result = /obj/item/reagent_containers/food/snacks/soup/peasoup
 	subcategory = CAT_SOUP
 
-/*
+
 /datum/crafting_recipe/food/wishsoup
 	name = "Wish soup"
 	reqs = list(
@@ -245,7 +245,7 @@
 	result = /obj/item/reagent_containers/food/snacks/soup/spacylibertyduff
 	subcategory = CAT_SOUP
 
-	/datum/crafting_recipe/food/slimesoup
+/datum/crafting_recipe/food/slimesoup
 	name = "Slime soup"
 	reqs = list(
 			/datum/reagent/water = 10,
@@ -278,4 +278,4 @@
 	)
 	result = /obj/item/reagent_containers/food/snacks/soup/coldchili
 	subcategory = CAT_SOUP
-*/
+

--- a/code/modules/hydroponics/grown/broc.dm
+++ b/code/modules/hydroponics/grown/broc.dm
@@ -29,4 +29,5 @@
 	if(..())
 		reagents.add_reagent(/datum/reagent/dexalin, 1 + round((seed.potency / 5), 1))
 		reagents.add_reagent(/datum/reagent/medicine/salglu_solution, 1 + round((seed.potency / 20), 1))
+		reagents.add_reagent(/datum/reagent/consumable/brocjuice, 1 + round((seed.potency / 5), 1))
 		bitesize = 1 + round(reagents.total_volume / 3, 1)

--- a/code/modules/hydroponics/grown/xander.dm
+++ b/code/modules/hydroponics/grown/xander.dm
@@ -27,6 +27,7 @@
 /obj/item/reagent_containers/food/snacks/grown/xander/add_juice()
 	if(..())
 		reagents.add_reagent(/datum/reagent/medicine/antitoxin, 1 + round((seed.potency / 5), 1))
+		reagents.add_reagent(/datum/reagent/consumable/xanderjuice, 1 + round((seed.potency/5), 1))
 		reagents.add_reagent(/datum/reagent/medicine/salglu, 1 + round((seed.potency / 20), 1))
 		bitesize = 1 + round(reagents.total_volume / 3, 1)
 

--- a/code/modules/reagents/chemistry/reagents/food_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/food_reagents.dm
@@ -380,6 +380,20 @@
 		return
 	new/obj/effect/decal/cleanable/salt(T)
 
+/datum/reagent/consumable/brocjuice
+	name = "Broc Flower Juice"
+	description = "The juice of a ground-up broc flower."
+	nutriment_factor = 1 * REAGENTS_METABOLISM
+	color = "#302000" // rgb: 48, 32, 0
+	taste_description = "flowers"
+
+/datum/reagent/consumable/xanderjuice
+	name = "Xander Root Juice"
+	description = "Ground up xander root, mashed into juicy pulp."
+	nutriment_factor = 1 * REAGENTS_METABOLISM
+	color = "#302000" // rgb: 48, 32, 0
+	taste_description = "dirt"
+
 /datum/reagent/consumable/blackpepper
 	name = "Black Pepper"
 	description = "A powder ground from peppercorns. *AAAACHOOO*"
@@ -511,7 +525,7 @@
 	nutriment_factor = 12 * REAGENTS_METABOLISM
 	value = REAGENT_VALUE_UNCOMMON
 	color = "#302000" // rgb: 48, 32, 0
-	taste_description = "slime"
+	taste_description = "corn"
 
 /datum/reagent/consumable/cornoil/reaction_turf(turf/open/T, reac_volume)
 	if (!istype(T))

--- a/code/modules/reagents/chemistry/reagents/impure_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/impure_reagents.dm
@@ -23,3 +23,27 @@
 	else
 		C.adjustToxLoss(2)
 	..()
+
+/datum/reagent/impure/impurestimpak
+	name = "Impure Stimpak Fluid"
+	description = "Stimpak production is a hard process, and improperly prepared stimpak fluid is toxic."
+	can_synth = FALSE
+	color = "FFFFFF"
+
+/datum/reagent/impure/impurestimpak/on_mob_life(mob/living/carbon/C)
+	C.adjustToxLoss(2)
+	..()
+
+/datum/reagent/impure/failedstimpak
+	name = "something that's probably not stimpak fluid"
+	description = "How? How did you do this?"
+	can_synth = FALSE
+	color = "#302000"
+	taste_description = "horrible, horrible burning"
+	taste_mult = 52
+	metabolization_rate = 0.6
+
+/datum/reagent/impure/failedstimpak/on_mob_life(mob/living/carbon/C)
+	C.blood_volume -= 10
+	C.adjustCloneLoss(2, 0)
+	..()

--- a/code/modules/reagents/chemistry/recipes/medicine.dm
+++ b/code/modules/reagents/chemistry/recipes/medicine.dm
@@ -369,13 +369,44 @@ datum/chemical_reaction/rezadone
 	for(var/i = 1, i <= created_volume, i++)
 		new /obj/item/stack/medical/mesh/(location)
 
-/*/datum/chemical_reaction/stimpak
+/datum/chemical_reaction/stimpak
 	name = "Stimpak Fluid"
 	id = /datum/reagent/medicine/stimpak
 	results = list(/datum/reagent/medicine/stimpak = 1)
 	required_reagents = list(/datum/reagent/blood = 1, /datum/reagent/medicine/spaceacillin = 1)
-	required_temp = 300
-*/
+	OptimalTempMin 		= 500 // Lower area of bell curve for determining heat based rate reactions
+	OptimalTempMax		= 550 // Upper end for above
+	ExplodeTemp			= 9999 //Temperature at which reaction explodes
+	OptimalpHMin		= 3 // Lowest value of pH determining pH a 1 value for pH based rate reactions (Plateu phase)
+	OptimalpHMax		= 8 // Higest value for above
+	ReactpHLim			= 4 // How far out pH wil react, giving impurity place (Exponential phase)
+	CurveSharpT 		= 5 // How sharp the temperature exponential curve is (to the power of value)
+	CurveSharppH 		= 0.5 // How sharp the pH exponential curve is (to the power of value)
+	ThermicConstant		= -6 //Temperature change per 1u produced
+	HIonRelease 		= -0.1 //pH change per 1u reaction
+	RateUpLim 			= 5 //Optimal/max rate possible if all conditions are perfect
+	FermiChem 			= TRUE//If the chemical uses the Fermichem reaction mechanics
+	FermiExplode 		= FALSE //If the chemical explodes in a special way
+
+/datum/chemical_reaction/stimpak2
+	name = "Imitation Stimpak Fluid"
+	id = /datum/reagent/medicine/stimpak/imitation
+	results = list(/datum/reagent/medicine/stimpak/imitation = 1)
+	required_reagents = list(/datum/reagent/consumable/brocjuice = 3, /datum/reagent/consumable/xanderjuice = 3)
+	OptimalTempMin 		= 500 // Lower area of bell curve for determining heat based rate reactions
+	OptimalTempMax		= 650 // Upper end for above
+	ExplodeTemp			= 9999 //Temperature at which reaction explodes
+	OptimalpHMin		= 2 // Lowest value of pH determining pH a 1 value for pH based rate reactions (Plateu phase)
+	OptimalpHMax		= 8 // Higest value for above
+	ReactpHLim			= 4 // How far out pH wil react, giving impurity place (Exponential phase)
+	CurveSharpT 		= 5 // How sharp the temperature exponential curve is (to the power of value)
+	CurveSharppH 		= 0.5 // How sharp the pH exponential curve is (to the power of value)
+	ThermicConstant		= -6 //Temperature change per 1u produced
+	HIonRelease 		= -0.1 //pH change per 1u reaction
+	RateUpLim 			= 12 //Optimal/max rate possible if all conditions are perfect
+	FermiChem 			= TRUE//If the chemical uses the Fermichem reaction mechanics
+	FermiExplode 		= FALSE //If the chemical explodes in a special way
+
 
 /datum/chemical_reaction/mentats
 	name = "mentats"

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -178,7 +178,7 @@
 	icon_state = "stimpakpen"
 	volume = 10
 	amount_per_transfer_from_this = 10
-	list_reagents = list(/datum/reagent/medicine/stimpak = 10, /datum/reagent/medicine/stimulants = 10, /datum/reagent/medicine/omnizine = 10)
+	list_reagents = list(/datum/reagent/medicine/stimpak = 10)
 
 /obj/item/reagent_containers/hypospray/medipen/stimpak/on_reagent_change(changetype)
 	update_icon()
@@ -192,6 +192,10 @@
 /obj/item/reagent_containers/hypospray/medipen/stimpak/custom
 	desc = "A handheld delivery system for medicine, this particular one will deliver a tailored cocktail."
 	list_reagents = null
+
+/obj/item/reagent_containers/hypospray/medipen/stimpak/imitation
+	desc = "A handheld delivery system for medicine. This one is filled with ground up flower juice, but hey, whatever gets you moving, right?"
+	list_reagents = list(/datum/reagent/medicine/stimpak/imitation = 10)
 
 /obj/item/reagent_containers/hypospray/medipen/stimpak/super
 	name = "super stimpak"


### PR DESCRIPTION
so a list of changes

1. you can craft stimpaks now through chemistry via mixing blood and spaceacilln at a temperature between 500 and 550 and if you go over that you get (problems)

the stimpak reaction will yield stimpak fluid at relatively high rates but quickly decrease the temperature of the reaction, requiring constant monitoring

honestly the pH window is so lenient as to be nonexistent, and i might  tighten that up to give more room for error

there's also imitation stimpak fluid, obtained either through no effort whatsoever in chemistry OR just regular chemistry-it is less effective than proper stimpak fluid, but more effective than healing powder (i may tweak its numbers some).

to clarify everyone still spawns with real stims, but you either need chemistry to make more real stims, or you loot them. in the interim, you craft basic bitch improvised stimpaks instead.

also it turned out bitter drink was actually stronger than fucking super stims so i toned that down some. hopefully that addresses the fact that the legion actually get BETTER healing than anyone else in the game. i may tweak this further, honestly, because it doesn't seem like any other chem cares if you have bitter drink in your system and you can stack it, but whatever.

there were leftover reagents in stimpaks, which ir emoved (they were code bloat, they did not appear anyway.)

fucking up the proper chem stimpak reaction yields impure stimpak reagent and something else, so...don't fuck it up.

final change, corn no longer tastes like slime

## Why It's Good For The Game

honestly i dunno maybe some more use for chemistry that's not making bicaridine/salicylic stimpaks and reduces loresmash of people producing real functional pre-war stimpaks out of nowhere with no chemistry knowledge

## Pre-Merge Checklist
- [x] Your Pull Request contains no breaking changes
- [x] You tested your changes locally, and they work.
- [x] There are no new Runtimes that appear.
- [x] You documented all of your changes.

<!-- Please check these accordingly. -->

## Changelog
:cl:
add: Added imitation stimpaks, craftable or makeable through chemistry.
add: Added making stimpaks through chemistry. Don't fuck up.
balance: Bitter drink heals less than super stimpaks, now.
fix: Corn no longer tastes like slime.
/:cl:
