### PR TITLE
Mob rebalance I: Ghouls and Wastebots

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/f13/Securitron.dm
+++ b/code/modules/mob/living/simple_animal/hostile/f13/Securitron.dm
@@ -21,8 +21,8 @@
 	move_to_delay = 5
 	stat_attack = SOFT_CRIT
 	robust_searching = TRUE
-	maxHealth = 250
-	health = 250
+	maxHealth = 150
+	health = 150
 	blood_volume = 0
 	del_on_death = TRUE
 	healable = FALSE
@@ -98,8 +98,8 @@
 	icon_state = "sentrybot"
 	icon_living = "sentrybot"
 	icon_dead = "sentrybot"
-	health = 280
-	maxHealth = 280
+	health = 210
+	maxHealth = 210
 	del_on_death = FALSE
 	melee_damage_lower = 48
 	melee_damage_upper = 72

--- a/code/modules/mob/living/simple_animal/hostile/f13/ghoul.dm
+++ b/code/modules/mob/living/simple_animal/hostile/f13/ghoul.dm
@@ -16,8 +16,8 @@
 	speak_emote = list("growls")
 	emote_see = list("screeches")
 	a_intent = INTENT_HARM
-	maxHealth = 80
-	health = 80
+	maxHealth = 60
+	health = 60
 	speed = 3
 	harm_intent_damage = 8
 	melee_damage_lower = 15
@@ -50,8 +50,8 @@
 	icon_living = "ghoulreaver"
 	icon_dead = "ghoulreaver_dead"
 	speed = 2
-	maxHealth = 150
-	health = 150
+	maxHealth = 120
+	health = 120
 	harm_intent_damage = 8
 	melee_damage_lower = 25
 	melee_damage_upper = 25
@@ -118,8 +118,8 @@
 	icon_state = "glowinghoul"
 	icon_living = "glowinghoul"
 	icon_dead = "glowinghoul_dead"
-	maxHealth = 160
-	health = 160
+	maxHealth = 100
+	health = 100
 	speed = 2
 	harm_intent_damage = 8
 	melee_damage_lower = 25

--- a/code/modules/mob/living/simple_animal/hostile/f13/wastebots.dm
+++ b/code/modules/mob/living/simple_animal/hostile/f13/wastebots.dm
@@ -204,8 +204,8 @@
 	icon_state = "protectron"
 	icon_living = "protectron"
 	icon_dead = "protectron_dead"
-	health = 160
-	maxHealth = 160
+	health = 130
+	maxHealth = 130
 	speed = 4
 	melee_damage_lower = 5 //severely reduced melee damage here because its silly to have a ranged mob also be a cqc master
 	melee_damage_upper = 10


### PR DESCRIPTION
## About The Pull Request

Decreases the health of ghouls, ghoul reavers, glowing ghouls, protectrons, securitrons, and sentry bots. These numbers are not by any means final, and will need live-testing to see how they feel.

## Why It's Good For The Game

Mobs are health sponges. This is not a good thing. It doesn't make them harder to fight, it just makes them more tedious (and forces players to hoard ammo). Let's fix that.

## Pre-Merge Checklist
- [x] Your Pull Request contains no breaking changes
- [ ] You tested your changes locally, and they work.
- [ ] There are no new Runtimes that appear.
- [x] You documented all of your changes.

<!-- Please check these accordingly. -->

## Changelog
:cl:
balance: Ghoul health reduced from 80 to 60, reaver health reduced from 150 to 120, glowing ghoul health reduced from 160 to 100.
balance: Sentry bot health reduced from 280 to 210, securitron health reduced from 250 to 150, and protectron health reduced from 160 to 130.
/:cl:

