### PR TITLE
Bola tuneup

### DIFF
--- a/code/game/objects/items/handcuffs.dm
+++ b/code/game/objects/items/handcuffs.dm
@@ -331,8 +331,9 @@
 	name = "bola"
 	desc = "A restraining device designed to be thrown at the target. Upon connecting with said target, it will wrap around their legs, making it difficult for them to move quickly."
 	icon_state = "bola"
-	breakouttime = 35//easy to apply, easy to break out of
+	breakouttime = 0.5//easy to apply, easy to break out of
 	gender = NEUTER
+	slowdown = 0.4
 	var/knockdown = 0
 
 /obj/item/restraints/legcuffs/bola/throw_at(atom/target, range, speed, mob/thrower, spin=1, diagonals_first = 0, datum/callback/callback)
@@ -367,8 +368,8 @@
 	name = "reinforced bola"
 	desc = "A strong bola, made with a long steel chain. It looks heavy, enough so that it could trip somebody."
 	icon_state = "bola_r"
-	breakouttime = 70
-	knockdown = 20
+	breakouttime = 3.5
+	slowdown = 7
 
 /obj/item/restraints/legcuffs/bola/energy //For Security
 	name = "energy bola"

--- a/code/game/objects/items/handcuffs.dm
+++ b/code/game/objects/items/handcuffs.dm
@@ -331,9 +331,9 @@
 	name = "bola"
 	desc = "A restraining device designed to be thrown at the target. Upon connecting with said target, it will wrap around their legs, making it difficult for them to move quickly."
 	icon_state = "bola"
-	breakouttime = 0.5//easy to apply, easy to break out of
+	breakouttime = 1.5//easy to apply, easy to break out of
 	gender = NEUTER
-	slowdown = 0.4
+	slowdown = 1.3
 	var/knockdown = 0
 
 /obj/item/restraints/legcuffs/bola/throw_at(atom/target, range, speed, mob/thrower, spin=1, diagonals_first = 0, datum/callback/callback)


### PR DESCRIPTION
bolas slow you down less now, and are much faster to break out of.

You still need to stand still to take them off, but the slowdown is no longer insane and makes you a sitting duck. They're instead a slowdown akin to wearing salvaged PA. You're not doomed, but you're definitely not outrunning anyone.

Reinforced bolas have the old bola stats.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.

:cl:
balance: Bolas are less unfair.
/:cl:

