### PR TITLE
Fixes up salvaging a bit, adds new blueprints

### DIFF
--- a/code/datums/components/crafting/recipes/recipes_weapon_and_ammo.dm
+++ b/code/datums/components/crafting/recipes/recipes_weapon_and_ammo.dm
@@ -446,6 +446,32 @@
 	subcategory = CAT_WEAPON
 	always_availible = FALSE
 
+/datum/crafting_recipe/pps
+	name = "Ppsh-41"
+	result = /obj/item/gun/ballistic/automatic/smg/ppsh
+	reqs = list(/obj/item/stack/sheet/metal = 5,
+				/obj/item/advanced_crafting_components/receiver = 1,
+				/obj/item/stack/crafting/metalparts = 2
+				)
+	tools = list(TOOL_AWORKBENCH)
+	time = 120
+	category = CAT_WEAPONRY
+	subcategory = CAT_WEAPON
+	always_availible = FALSE
+
+/datum/crafting_recipe/commando
+	name = "DeLisle Commando Carbine"
+	result = /obj/item/gun/ballistic/automatic/delisle/commando
+	reqs = list(/obj/item/stack/sheet/metal = 5,
+				/obj/item/advanced_crafting_components/receiver = 1,
+				/obj/item/stack/crafting/metalparts = 2
+				)
+	tools = list(TOOL_WORKBENCH)
+	time = 120
+	category = CAT_WEAPONRY
+	subcategory = CAT_WEAPON
+	always_availible = FALSE
+
 //infiltrator
 /datum/crafting_recipe/infiltrator
 	name = "Infiltrator Carbine"
@@ -551,6 +577,39 @@
 	category = CAT_WEAPONRY
 	subcategory = CAT_WEAPON
 	always_availible = FALSE
+
+/datum/crafting_recipe/gaussrifle
+	name = "M72 Gauss Rifle"
+	reqs = list(/obj/item/stack/sheet/metal = 15,
+				/obj/item/advanced_crafting_components/flux = 1,
+				/obj/item/advanced_crafting_components/conductors = 2,
+				/obj/item/advanced_crafting_components/alloys = 2,
+				/obj/item/advanced_crafting_components/assembly = 1,
+				/obj/item/advanced_crafting_components/receiver = 1,
+				/obj/item/stack/crafting/metalparts = 5,
+				/obj/item/stack/crafting/electronicparts = 15
+				)
+	tools = list(TOOL_AWORKBENCH)
+	time = 120
+	category = CAT_WEAPONRY
+	subcategory = CAT_WEAPON
+	always_availible = FALSE
+
+/datum/crafting_recipe/neostead
+	name = "Neostead 2000"
+	result = /obj/item/gun/ballistic/shotgun/automatic/combat/neostead
+	reqs = list(/obj/item/stack/sheet/metal = 10,
+				/obj/item/advanced_crafting_components/assembly = 1,
+				/obj/item/advanced_crafting_components/alloys = 1,
+				/obj/item/advanced_crafting_components/receiver = 1,
+				/obj/item/stack/crafting/goodparts = 15,
+				)
+	tools = list(TOOL_AWORKBENCH)
+	time = 120
+	category = CAT_WEAPONRY
+	subcategory = CAT_WEAPON
+	always_availible = FALSE
+
 
 //aep7
 /datum/crafting_recipe/AEP7
@@ -715,6 +774,19 @@
 	reqs = list(/obj/item/stack/sheet/metal = 5,
 				/obj/item/advanced_crafting_components/assembly = 1,
 				/obj/item/advanced_crafting_components/alloys = 1,
+				/obj/item/stack/sheet/mineral/wood = 5,
+				/obj/item/stack/crafting/goodparts = 5
+				)
+	tools = list(TOOL_WORKBENCH)
+	time = 120
+	category = CAT_WEAPONRY
+	subcategory = CAT_WEAPON
+	always_availible = FALSE
+
+/datum/crafting_recipe/m1carbine
+	name = "M1 Carbine"
+	result = /obj/item/gun/ballistic/automatic/m1carbine
+	reqs = list(/obj/item/stack/sheet/metal = 5,
 				/obj/item/stack/sheet/mineral/wood = 5,
 				/obj/item/stack/crafting/goodparts = 5
 				)
@@ -932,6 +1004,7 @@
 
 
 
+
 //////////////////////////////////
 ///GUN ATTACHMENT/PARTS CRAFTING//
 //////////////////////////////////
@@ -1006,8 +1079,6 @@
 	category = CAT_WEAPONRY
 	subcategory = CAT_PARTS
 	always_availible = FALSE
-
-
 /*
 /datum/crafting_recipe/flux
 	name = "Flux capacitor"

--- a/code/datums/components/crafting/recipes/recipes_weapon_and_ammo.dm
+++ b/code/datums/components/crafting/recipes/recipes_weapon_and_ammo.dm
@@ -580,6 +580,7 @@
 
 /datum/crafting_recipe/gaussrifle
 	name = "M72 Gauss Rifle"
+	result = /obj/item/gun/ballistic/automatic/m72
 	reqs = list(/obj/item/stack/sheet/metal = 15,
 				/obj/item/advanced_crafting_components/flux = 1,
 				/obj/item/advanced_crafting_components/conductors = 2,

--- a/code/game/objects/effects/spawners/f13lootdrop.dm
+++ b/code/game/objects/effects/spawners/f13lootdrop.dm
@@ -1786,8 +1786,15 @@
 		/obj/item/book/granter/crafting_recipe/blueprint/marksman,
 		/obj/item/book/granter/crafting_recipe/blueprint/plasmapistol,
 		/obj/item/book/granter/crafting_recipe/blueprint/brushgun,
-		/obj/item/book/granter/crafting_recipe/blueprint/aer9,
 		/obj/item/book/granter/crafting_recipe/blueprint/greasegun,
+		/obj/item/book/granter/crafting_recipe/blueprint/r82,
+		/obj/item/book/granter/crafting_recipe/blueprint/service,
+		/obj/item/book/granter/crafting_recipe/blueprint/trailcarbine,
+		/obj/item/book/granter/crafting_recipe/blueprint/thatgun,
+		/obj/item/book/granter/crafting_recipe/blueprint/uzi,
+		/obj/item/book/granter/crafting_recipe/blueprint/smg10mm,
+		/obj/item/book/granter/crafting_recipe/blueprint/m1carbine,
+		/obj/item/book/granter/crafting_recipe/blueprint/scoutcarbine
 	)
 
 /obj/effect/spawner/lootdrop/f13/blueprintHigh
@@ -1799,7 +1806,11 @@
 		/obj/item/book/granter/crafting_recipe/blueprint/sniper,
 		/obj/item/book/granter/crafting_recipe/blueprint/riotshotgun,
 		/obj/item/book/granter/crafting_recipe/blueprint/r84,
-		/obj/item/book/granter/crafting_recipe/blueprint/deagle
+		/obj/item/book/granter/crafting_recipe/blueprint/deagle,
+		/obj/item/book/granter/crafting_recipe/blueprint/commando,
+		/obj/item/book/granter/crafting_recipe/blueprint/pps,
+		/obj/item/book/granter/crafting_recipe/blueprint/leveraction,
+		/obj/item/book/granter/crafting_recipe/blueprint/aep7
 	)
 
 /obj/effect/spawner/lootdrop/f13/blueprintVHigh
@@ -1809,7 +1820,10 @@
 	loot = list(
 		/obj/item/book/granter/crafting_recipe/blueprint/am_rifle,
 		/obj/item/book/granter/crafting_recipe/blueprint/citykiller,
-		/obj/item/book/granter/crafting_recipe/blueprint/rangemaster
+		/obj/item/book/granter/crafting_recipe/blueprint/rangemaster,
+		/obj/item/book/granter/crafting_recipe/blueprint/neostead,
+		/obj/item/book/granter/crafting_recipe/blueprint/aer9,
+		/obj/item/book/granter/crafting_recipe/blueprint/gauss
 	)
 
 /obj/effect/spawner/lootdrop/f13/blueprintVHighBallistics

--- a/code/game/objects/items/granters.dm
+++ b/code/game/objects/items/granters.dm
@@ -769,7 +769,7 @@
 /obj/item/book/granter/crafting_recipe/blueprint/m1carbine
 	name = "m1 carbine blueprint"
 	icon_state = "blueprint2"
-	crafting_recipe_types = list(/datum/crafting_recipe/gun/lsw)
+	crafting_recipe_types = list(/datum/crafting_recipe/m1carbine)
 
 /obj/item/book/granter/crafting_recipe/blueprint/pps
 	name = "ppsh-41 blueprint"

--- a/code/game/objects/items/granters.dm
+++ b/code/game/objects/items/granters.dm
@@ -766,6 +766,21 @@
 	icon_state = "blueprint2"
 	crafting_recipe_types = list(/datum/crafting_recipe/gun/lsw)
 
+/obj/item/book/granter/crafting_recipe/blueprint/m1carbine
+	name = "m1 carbine blueprint"
+	icon_state = "blueprint2"
+	crafting_recipe_types = list(/datum/crafting_recipe/gun/lsw)
+
+/obj/item/book/granter/crafting_recipe/blueprint/pps
+	name = "ppsh-41 blueprint"
+	icon_state = "blueprint2"
+	crafting_recipe_types = list(/datum/crafting_recipe/pps)
+
+/obj/item/book/granter/crafting_recipe/blueprint/commando
+	name = "commando carbine blueprint"
+	icon_state = "blueprint2"
+	crafting_recipe_types = list(/datum/crafting_recipe/commando)
+
 /obj/item/book/granter/crafting_recipe/blueprint/trapper
 	name = "guide to minelaying"
 	icon_state = "blueprint2"
@@ -787,6 +802,16 @@
 	name = "scout carbine blueprint"
 	icon_state = "blueprint2"
 	crafting_recipe_types = list(/datum/crafting_recipe/scoutcarbine)
+
+/obj/item/book/granter/crafting_recipe/blueprint/neostead
+	name = "neostead 2000 blueprint"
+	icon_state = "blueprint2"
+	crafting_recipe_types = list(/datum/crafting_recipe/neostead)
+
+/obj/item/book/granter/crafting_recipe/blueprint/gauss
+	name = "gauss rifle blueprint"
+	icon_state = "blueprint2"
+	crafting_recipe_types = list(/datum/crafting_recipe/gaussrifle)
 
 /obj/item/book/granter/crafting_recipe/manual/denvr
 	name = "den vr configuration"

--- a/code/game/objects/structures/wrecks.dm
+++ b/code/game/objects/structures/wrecks.dm
@@ -355,8 +355,8 @@
 		if(!I.use_tool(src, user, 0, volume=100)) //here is the dilemma, use_tool doesn't work like do_after, so moving away screws it(?)
 			inuse = FALSE
 			return //you can't use the tool, so stop
-		for(var/i1 in 1 to 2) //so, I hate waiting 30 seconds straight... what if we wait 10 seconds 3 times? (yes, its the same, but it'll feel more!)
-			if(!do_after(user, 10 SECONDS*W.toolspeed, target = src)) //this is my work around, because do_After does have a move away
+		for(var/i1 in 1 to 2) //so, I hate waiting
+			if(!do_after(user, 3 SECONDS*W.toolspeed, target = src)) //this is my work around, because do_After does have a move away
 				user.visible_message("[user] stops disassembling [src].")
 				inuse = FALSE
 				return //you did something, like moving, so stop
@@ -401,8 +401,8 @@
 		if(!I.use_tool(src, user, 0, volume=100)) //here is the dilemma, use_tool doesn't work like do_after, so moving away screws it(?)
 			inuse = FALSE
 			return //you can't use the tool, so stop
-		for(var/i1 in 1 to 2) //so, I hate waiting 30 seconds straight... what if we wait 10 seconds 3 times? (yes, its the same, but it'll feel more!)
-			if(!do_after(user, 10 SECONDS, target = src)) //this is my work around, because do_After does have a move away
+		for(var/i1 in 1 to 2) //so, I hate waiting
+			if(!do_after(user, 3 SECONDS, target = src)) //this is my work around, because do_After does have a move away
 				user.visible_message("[user] stops disassembling [src].")
 				inuse = FALSE
 				return //you did something, like moving, so stop

--- a/code/modules/crafting/items.dm
+++ b/code/modules/crafting/items.dm
@@ -937,43 +937,28 @@
 				/obj/item/stack/ore/blackpowder/two,
 				/obj/item/stack/crafting/electronicparts/three,
 				/obj/item/stack/sheet/mineral/titanium,
-				/obj/item/stack/sheet/mineral/gold,
-				/obj/item/stack/sheet/mineral/silver,
-				/obj/item/stack/sheet/lead/five,
 				/obj/item/stack/sheet/metal/ten,
 				/obj/item/stack/sheet/glass/ten,
 				/obj/item/stack/sheet/cloth/five,
 				/obj/item/stack/sheet/leather/five,
 				/obj/item/scrap/research,
 				/obj/item/stock_parts/cell/ammo/ec,
-				/obj/item/stack/crafting/goodparts
+				/obj/item/stack/crafting/goodparts/five
 				)
 
 /obj/item/salvage/crafting
 	name = "salvaged components"
 	desc = "Some salvaged components, it could contain some useful materials if dissasembled using a workbench..."
 	icon_state = "salvagecomponents"
-	Loot = list(/obj/item/crafting/diode,
-				/obj/item/crafting/transistor,
-				/obj/item/crafting/capacitor,
-				/obj/item/crafting/fuse,
-				/obj/item/crafting/resistor,
-				/obj/item/crafting/switch_crafting,
-				/obj/item/crafting/bulb,
-				/obj/item/crafting/board,
-				/obj/item/crafting/buzzer,
-				/obj/item/crafting/frame,
-				/obj/item/crafting/small_gear,
-				/obj/item/crafting/large_gear,
-				/obj/item/crafting/duct_tape,
+	Loot = list(/obj/item/crafting/duct_tape,
 				/obj/item/crafting/coffee_pot,
 				/obj/item/crafting/wonderglue,
-				/obj/item/crafting/turpentine,
 				/obj/item/crafting/abraxo,
 				/obj/item/crafting/igniter,
 				/obj/item/crafting/timer,
 				/obj/item/crafting/sensor,
-				/obj/item/crafting/lunchbox)
+				/obj/item/crafting/lunchbox,
+				/obj/item/reagent_containers/glass/bottle/blackpowder)
 
 /obj/item/salvage/tool
 	name = "Pre-war tool salvage"
@@ -981,16 +966,16 @@
 	icon_state = "toolsalvage"
 	Loot = list(/obj/item/blueprint/research,
 				/obj/item/reagent_containers/hypospray/medipen/stimpak,
-				/obj/item/reagent_containers/pill/patch/healingpowder,
-				/obj/item/stack/ore/blackpowder/two,
+				/obj/item/reagent_containers/pill/patch/healpoultice,
 				/obj/item/weldingtool/advanced,
 				/obj/item/crowbar/hightech,
 				/obj/item/screwdriver/hightech,
 				/obj/item/wrench/hightech,
 				/obj/item/wirecutters/hightech,
+				/obj/item/multitool/advanced,
 				/obj/item/stock_parts/cell/ammo/mfc,
 				/obj/item/stock_parts/cell/ammo/ecp,
-				/obj/item/melee/onehanded/knife/switchblade,
+				/obj/item/melee/onehanded/knife/cosmic,
 				/obj/item/megaphone)
 
 /obj/item/salvage/high
@@ -999,5 +984,13 @@
 	icon_state = "goodsalvage"
 	Loot = list(/obj/item/advanced_crafting_components/receiver,
 				/obj/item/advanced_crafting_components/assembly,
-				/obj/item/advanced_crafting_components/alloys)
+				/obj/item/advanced_crafting_components/alloys,
+				/obj/item/advanced_crafting_components/conductors,
+				/obj/item/advanced_crafting_components/lenses,
+				/obj/item/advanced_crafting_components/flux,
+				/obj/item/attachments/scope,
+				/obj/item/suppressor,
+				/obj/item/attachments/burst_improvement,
+				/obj/item/attachments/recoil_decrease,
+				/obj/item/attachments/auto_sear)
 

--- a/fortune13.dme
+++ b/fortune13.dme
@@ -3162,8 +3162,6 @@
 #include "code\modules\projectiles\projectile\bullets\pistol.dm"
 #include "code\modules\projectiles\projectile\bullets\rifle.dm"
 #include "code\modules\projectiles\projectile\bullets\shotgun.dm"
-#include "code\modules\projectiles\projectile\bullets\smg.dm"
-#include "code\modules\projectiles\projectile\bullets\sniper.dm"
 #include "code\modules\projectiles\projectile\bullets\special.dm"
 #include "code\modules\projectiles\projectile\energy\_energy.dm"
 #include "code\modules\projectiles\projectile\energy\ebow.dm"

--- a/fortune13.dme
+++ b/fortune13.dme
@@ -3162,6 +3162,8 @@
 #include "code\modules\projectiles\projectile\bullets\pistol.dm"
 #include "code\modules\projectiles\projectile\bullets\rifle.dm"
 #include "code\modules\projectiles\projectile\bullets\shotgun.dm"
+#include "code\modules\projectiles\projectile\bullets\smg.dm"
+#include "code\modules\projectiles\projectile\bullets\sniper.dm"
 #include "code\modules\projectiles\projectile\bullets\special.dm"
 #include "code\modules\projectiles\projectile\energy\_energy.dm"
 #include "code\modules\projectiles\projectile\energy\ebow.dm"


### PR DESCRIPTION
We had a deficit of blueprints and crafting sucks.

While not making crafting any less shit, I sped up salvaging and removed some useless salvage in favor of useful rewards, and I increased the available amount of blueprints and the lootpools that spawn them.

You can now have blueprints for the ppsh-41, the Delisle, the Neostead, the gauss rifle, the m1 carbine, the r82, the uzi, the trail carbine, the .556 pistol, the 10mm smg, the scout carbine, the lever action, the AEP7, the service rifle...

Basically, you have a lot more lootable craftable blueprints.

The speed at which you salvage has also been decreased

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.

:cl:
add: More gun blueprints have been added.
tweak: Salvaging is less AIDS.
/:cl:

