### PR TITLE
Khan loadouts

### DIFF
--- a/code/modules/jobs/job_types/wasteland.dm
+++ b/code/modules/jobs/job_types/wasteland.dm
@@ -287,18 +287,18 @@ Great Khan
 
 /datum/outfit/loadout/enforcer
 	name = "Enforcer"
-	suit_store = /obj/item/gun/ballistic/revolver/caravan_shotgun
+	suit_store = /obj/item/gun/ballistic/shotgun/automatic/combat/shotgunlever
 	backpack_contents = list(
 		/obj/item/ammo_box/shotgun/buck=1, \
 		/obj/item/ammo_box/shotgun/bean=1, \
-		/obj/item/restraints/legcuffs/bola/tactical=1, \
+		/obj/item/storage/belt/bandolier, \
 		/obj/item/restraints/handcuffs=2)
 
 /datum/outfit/loadout/brawler
 	name = "Brawler"
 	gloves =	/obj/item/melee/unarmed/brass/spiked
 	backpack_contents = list(
-		/obj/item/twohanded/baseball/spiked=1, \
+		/obj/item/twohanded/sledgehammer, \
 		/obj/item/reagent_containers/pill/patch/healpoultice=2)
 
 /*

--- a/code/modules/jobs/job_types/wasteland.dm
+++ b/code/modules/jobs/job_types/wasteland.dm
@@ -288,10 +288,10 @@ Great Khan
 /datum/outfit/loadout/enforcer
 	name = "Enforcer"
 	suit_store = /obj/item/gun/ballistic/shotgun/automatic/combat/shotgunlever
+	belt = /obj/item/storage/belt/bandolier
 	backpack_contents = list(
 		/obj/item/ammo_box/shotgun/buck=1, \
 		/obj/item/ammo_box/shotgun/bean=1, \
-		/obj/item/storage/belt/bandolier, \
 		/obj/item/restraints/handcuffs=2)
 
 /datum/outfit/loadout/brawler


### PR DESCRIPTION

## About The Pull Request
     replace the double barrel shotgun of the enforcer khan loadout with a lever action shotgun, also added a bandolier to the same loadout. removed renforced bolas from the loadouts and replaced the spiked bat with a sledge hammer as well.

## Why It's Good For The Game
      these two loadouts are awfully weak outside of the renforced bola, for exemple the spiked bat does only as much damage as a simple machete. 

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.

## Changelog

:cl:
Changed the shotgun from the enforcer loadout to a lever action shotgun. Changed the bat of the brawler loadout to a sledge hammer. Removed the renforced bola.
/:cl:
