### PR TITLE
no more space fries

### DIFF
--- a/code/modules/food_and_drinks/food/snacks_other.dm
+++ b/code/modules/food_and_drinks/food/snacks_other.dm
@@ -94,7 +94,7 @@
 	foodtype = VEGETABLES | DAIRY
 
 /obj/item/reagent_containers/food/snacks/fries
-	name = "space fries"
+	name = "fries"
 	desc = "AKA: French Fries, Freedom Fries, etc."
 	icon_state = "fries"
 	trash = /obj/item/trash/plate
@@ -368,7 +368,7 @@
 
 /obj/item/reagent_containers/food/snacks/nachos
 	name = "nachos"
-	desc = "Chips from Space Mexico."
+	desc = "These could really use some cheese."
 	icon_state = "nachos"
 	bonus_reagents = list(/datum/reagent/consumable/nutriment = 1, /datum/reagent/consumable/nutriment/vitamin = 1)
 	list_reagents = list(/datum/reagent/consumable/nutriment = 6, /datum/reagent/consumable/nutriment/vitamin = 2)

--- a/code/modules/instruments/instruments/stationary.dm
+++ b/code/modules/instruments/instruments/stationary.dm
@@ -32,7 +32,7 @@
 	return TRUE
 
 /obj/structure/musician/piano
-	name = "space minimoog"
+	name = "minimoog"
 	icon = 'icons/obj/musician.dmi'
 	icon_state = "minimoog"
 	anchored = TRUE
@@ -44,10 +44,10 @@
 /obj/structure/musician/piano/Initialize(mapload)
 	. = ..()
 	if(prob(50) && icon_state == initial(icon_state))
-		name = "space minimoog"
-		desc = "This is a minimoog, like a space piano, but more spacey!"
+		name = "minimoog"
+		desc = "This is a minimoog, like a piano, but more futuristic!"
 		icon_state = "minimoog"
 	else
-		name = "space piano"
-		desc = "This is a space piano, like a regular piano, but always in tune! Even if the musician isn't."
+		name = "piano"
+		desc = "This old piano can barely hold a tune. Too bad all the piano tuners are dead, more or less."
 		icon_state = "piano"


### PR DESCRIPTION
## About The Pull Request

renames space fries to just "fries"
also removes a mention of "space mexico" from the nachos description, and removes "space" from the minimoog/piano names

## Why It's Good For The Game

immersion

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->


## Changelog
<!-- This is mostly optional for small Pull Requests, but if you value being credited for your work in-game be sure to fill it out. To opt-out, remove everything below including the start and end :cl: brackets. -->

<!-- If your Pull Request includes a minor single line variable edit, probably do not fill out this changelog. -->
<!-- However, if your pull request includes massive or immediately noticeable changes, briefly describe those changes in some way in this changelog. -->

:cl:
fix: firmly grounded nachos and fries
fix: removed mentions of space from the minimoog and synthesizer
/:cl: