### PR TITLE
hitscan lasers in

### DIFF
--- a/code/modules/projectiles/ammunition/energy/laser.dm
+++ b/code/modules/projectiles/ammunition/energy/laser.dm
@@ -145,7 +145,7 @@ also: most hitscan weapons have more charge than their normal projectile counter
 	projectile_type = /obj/item/projectile/beam/laser/pistol/wattz/hitscan
 	e_cost = 53.33 //30 shots, as per FNV
 
-/obj/item/ammo_casing/energy/laser/pistol/wattz/magneto
+/obj/item/ammo_casing/energy/laser/pistol/wattz/magneto/hitscan
 	projectile_type = /obj/item/projectile/beam/laser/pistol/wattz/magneto/hitscan
 	e_cost = 53.33 //30 shots, as per FNV
 

--- a/code/modules/projectiles/ammunition/energy/laser.dm
+++ b/code/modules/projectiles/ammunition/energy/laser.dm
@@ -89,7 +89,17 @@
 ---Fallout 13---
 */
 
-/obj/item/ammo_casing/energy/laser/scatter
+/* here are the ammo sizes since nobody ever wrote these down
+electron chargepack = 2400, this is currently only used in the RCW
+mfc = 2000
+ec = 1600
+
+each one goes up by 4,000 power. why? nobody fucking knows lmao
+
+also: most hitscan weapons have more charge than their normal projectile counterparts, since the actual projectiles are lower in damage and AP. this is to represent spammability.
+*/
+
+/obj/item/ammo_casing/energy/laser/scatter/tribeam
 	projectile_type = /obj/item/projectile/beam/laser/tribeam
 	pellets = 3
 	variance = 14
@@ -97,15 +107,21 @@
 	e_cost = 180 //11 shots
 	fire_sound = 'sound/f13weapons/tribeamfire.ogg'
 
+/obj/item/ammo_casing/energy/laser/tribeam/hitscan
+	projectile_type = /obj/item/projectile/beam/laser/tribeam/hitscan
+	pellets = 3
+	variance = 45
+	select_name = "tribeam"
+	e_cost = 200 //10 shots
+
 /obj/item/ammo_casing/energy/laser/pistol
 	projectile_type = /obj/item/projectile/beam/laser/pistol
 	e_cost = 80 //20 shots
 	fire_sound = 'sound/f13weapons/aep7fire.ogg'
 
-/obj/item/ammo_casing/energy/laser/lucky37
-	projectile_type = /obj/item/projectile/beam/laser/pistol
-	e_cost = 180 //11 shots
-	fire_sound = 'sound/f13weapons/aep7fire.ogg'
+/obj/item/ammo_casing/energy/laser/pistol/hitscan //25 damage per, with 0 near 0 AP-4 shot crit on unarmored target, significantly less useful against armored
+	projectile_type = /obj/item/projectile/beam/laser/pistol/hitscan
+	e_cost = 53.33 //30 shots, as per FNV
 
 /obj/item/ammo_casing/energy/laser/ultra_pistol
 	projectile_type = /obj/item/projectile/beam/laser/ultra_pistol
@@ -125,33 +141,65 @@
 /obj/item/ammo_casing/energy/laser/pistol/wattz/magneto
 	projectile_type = /obj/item/projectile/beam/laser/pistol/wattz/magneto
 
+/obj/item/ammo_casing/energy/laser/pistol/wattz/hitscan
+	projectile_type = /obj/item/projectile/beam/laser/pistol/wattz/hitscan
+	e_cost = 53.33 //30 shots, as per FNV
+
+/obj/item/ammo_casing/energy/laser/pistol/wattz/magneto
+	projectile_type = /obj/item/projectile/beam/laser/pistol/wattz/magneto/hitscan
+	e_cost = 53.33 //30 shots, as per FNV
+
 /obj/item/ammo_casing/energy/laser/lasgun
 	projectile_type = /obj/item/projectile/beam/laser/lasgun
 	e_cost = 100 //20 shots
 	fire_sound = 'sound/f13weapons/aer9fire.ogg'
 
+/obj/item/ammo_casing/energy/laser/lasgun/hitscan
+	projectile_type = /obj/item/projectile/beam/laser/lasgun/hitscan
+	e_cost = 80 //25 shots, as per FNV
+
 /obj/item/ammo_casing/energy/laser/solar
 	projectile_type = /obj/item/projectile/beam/laser/solar
-	e_cost = 30 //10 shots, self-charges
+	e_cost = 30 //basically infinite shots
 	fire_sound = 'sound/f13weapons/laser_pistol.ogg'
+
+/obj/item/ammo_casing/energy/laser/solar/hitscan
+	projectile_type = /obj/item/projectile/beam/laser/solar/hitscan
+	e_cost = 125 //16 shots, self charges. selfchargng adds 100 each time it fires off, so 2 ticks per laser recharge.
 
 /obj/item/ammo_casing/energy/laser/rcw
 	projectile_type = /obj/item/projectile/beam/laser/rcw
-	e_cost = 100 //24 shots
+	e_cost = 100 //11 shots
 	fire_sound = 'sound/f13weapons/rcwfire.ogg'
+
+/obj/item/ammo_casing/energy/laser/rcw/hitscan
+	projectile_type = /obj/item/projectile/beam/laser/rcw/hitscan
+	e_cost = 50 //it's actually 24 shots now, as it fires in a burst of 2
 
 /obj/item/ammo_casing/energy/laser/laer
 	projectile_type = /obj/item/projectile/beam/laser/laer
 	e_cost = 125 //16 shots
 	fire_sound = 'sound/f13weapons/laerfire.ogg'
 
+/obj/item/ammo_casing/energy/laser/laer/hitscan
+	projectile_type = /obj/item/projectile/beam/laser/laer/hitscan
+
 /obj/item/ammo_casing/energy/laser/aer14
 	projectile_type = /obj/item/projectile/beam/laser/aer14
 	e_cost = 80 //25 shots
 	fire_sound = 'sound/f13weapons/aer14fire.ogg'
 
+/obj/item/ammo_casing/energy/laser/aer14/hitscan
+	projectile_type = /obj/item/projectile/beam/laser/aer14/hitscan
+	e_cost = 133.33 //15 shots, i hate the decimal value too trust me
+
 /obj/item/ammo_casing/energy/laser/aer12
 	projectile_type = /obj/item/projectile/beam/laser/aer12
+	e_cost = 100 //20 shots
+	fire_sound = 'sound/f13weapons/aer9fire.ogg'
+
+/obj/item/ammo_casing/energy/laser/aer12/hitscan
+	projectile_type = /obj/item/projectile/beam/laser/aer12/hitscan
 	e_cost = 100 //20 shots
 	fire_sound = 'sound/f13weapons/aer9fire.ogg'
 
@@ -164,9 +212,16 @@
 	projectile_type = /obj/item/projectile/beam/laser/wattz2k
 	e_cost = 125
 
+/obj/item/ammo_casing/energy/wattz2k/hitscan
+	projectile_type = /obj/item/projectile/beam/laser/wattz2k/hitscan
+	e_cost = 80 //25 //32.5 shots
+
 /obj/item/ammo_casing/energy/wattz2k/extended
 	projectile_type = /obj/item/projectile/beam/laser/wattz2k
-	e_cost = 62.5
+	e_cost = 62.5 //32.5 shots
+
+/obj/item/ammo_casing/energy/wattz2k/extended/hitscan
+	projectile_type = /obj/item/projectile/beam/laser/wattz2k/hitscan
 
 //musket
 
@@ -174,11 +229,6 @@
 	projectile_type = /obj/item/projectile/beam/laser/musket
 	e_cost = 250
 	fire_sound = 'sound/f13weapons/aer9fire.ogg'
-
-//f13 hitscan test, i'll delete this later if the basic works out
-/obj/item/ammo_casing/energy/laser/lasgun/hitscan
-	projectile_type = /obj/item/projectile/beam/laser/lasgun/hitscan
-	e_cost = 50
 
 // BETA // Obsolete
 /obj/item/ammo_casing/energy/laser/pistol/lasertest

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -203,11 +203,12 @@
 	righthand_file = 'icons/fallout/onmob/weapons/guns_righthand.dmi'
 	icon_state = "wattz1000"
 	item_state = "laser-pistol"
+	fire_delay = 0
 	slowdown = 0.2
 	w_class = WEIGHT_CLASS_NORMAL
 	weapon_weight = WEAPON_LIGHT
 	slot_flags = ITEM_SLOT_BELT
-	ammo_type = list(/obj/item/ammo_casing/energy/laser/pistol/wattz)
+	ammo_type = list(/obj/item/ammo_casing/energy/laser/pistol/wattz/hitscan)
 	cell_type = /obj/item/stock_parts/cell/ammo/ec
 	equipsound = 'sound/f13weapons/equipsounds/aep7equip.ogg'
 
@@ -216,8 +217,9 @@
 	name = "Wattz 1000 magneto-laser pistol"
 	desc = "This Wattz 1000 laser pistol has been upgraded with a magnetic field targeting system that tightens the laser emission, giving this pistol extra penetrating power."
 	icon_state = "magnetowattz"
+	fire_delay = 0
 	item_state = "laser-pistol"
-	ammo_type = list(/obj/item/ammo_casing/energy/laser/pistol/wattz/magneto)
+	ammo_type = list(/obj/item/ammo_casing/energy/laser/pistol/wattz/magneto/hitscan)
 
 
 //AEP 7 Laser pistol
@@ -230,9 +232,9 @@
 	w_class = WEIGHT_CLASS_NORMAL
 	weapon_weight = WEAPON_MEDIUM
 	slot_flags = ITEM_SLOT_BELT
-	ammo_type = list(/obj/item/ammo_casing/energy/laser/pistol)
+	ammo_type = list(/obj/item/ammo_casing/energy/laser/pistol/hitscan)
 	cell_type = /obj/item/stock_parts/cell/ammo/ec
-	fire_delay = 2
+	fire_delay = 0
 	can_scope = TRUE
 	scope_state = "AEP7_scope"
 	scope_x_offset = 7
@@ -250,10 +252,10 @@
 	weapon_weight = WEAPON_MEDIUM
 	w_class = WEIGHT_CLASS_NORMAL
 	slot_flags = ITEM_SLOT_BELT
-	ammo_type = list(/obj/item/ammo_casing/energy/laser/solar) //30 damage, 20 AP
-	cell_type = /obj/item/stock_parts/cell/ammo/ec //10 shots, self-charges
+	ammo_type = list(/obj/item/ammo_casing/energy/laser/solar/hitscan) //27 dmg, .15 AP
+	cell_type = /obj/item/stock_parts/cell/ammo/ec //16 shots, self-charges
 	can_charge = 0
-	selfcharge = 1
+	selfcharge = 1 //selfcharging adds 100 a shot
 	equipsound = 'sound/f13weapons/equipsounds/aep7equip.ogg'
 
 
@@ -290,8 +292,8 @@
 	righthand_file = 'icons/fallout/onmob/weapons/guns_righthand.dmi'
 	icon_state = "wattz2k"
 	item_state = "sniper_rifle"
-	fire_delay = 3.5
-	ammo_type = list(/obj/item/ammo_casing/energy/wattz2k)
+	fire_delay = 1
+	ammo_type = list(/obj/item/ammo_casing/energy/wattz2k/hitscan)
 	cell_type = /obj/item/stock_parts/cell/ammo/mfc
 	zoomable = TRUE
 	zoom_amt = 10
@@ -307,8 +309,8 @@
 	righthand_file = 'icons/fallout/onmob/weapons/guns_righthand.dmi'
 	icon_state = "wattz2k"
 	item_state = "sniper_rifle"
-	fire_delay = 3.5
-	ammo_type = list(/obj/item/ammo_casing/energy/wattz2k/extended)
+	fire_delay = 1
+	ammo_type = list(/obj/item/ammo_casing/energy/wattz2k/extended/hitscan)
 	cell_type = /obj/item/stock_parts/cell/ammo/mfc
 	zoomable = TRUE
 	zoom_amt = 10
@@ -325,8 +327,7 @@
 	item_state = "laser-rifle9"
 	ammo_type = list(/obj/item/ammo_casing/energy/laser/lasgun)
 	cell_type = /obj/item/stock_parts/cell/ammo/mfc
-	fire_delay = 3
-	can_scope = TRUE
+	fire_delay = 1
 	scope_state = "AEP7_scope"
 	scope_x_offset = 12
 	scope_y_offset = 20
@@ -358,8 +359,8 @@
 	desc = "A modified AER9 equipped with a refraction kit that spreads its bolts. It is usually only given to high-ranking soldiers within the Brotherhood, due to its level of technology, as well as its reputation of friendly fire."
 	icon_state = "tribeam"
 	item_state = "laser-rifle9"
-	fire_delay = 5
-	ammo_type = list(/obj/item/ammo_casing/energy/laser/scatter)
+	fire_delay = 3
+	ammo_type = list(/obj/item/ammo_casing/energy/laser/scatter/tribeam)
 	cell_type = /obj/item/stock_parts/cell/ammo/mfc
 	equipsound = 'sound/f13weapons/equipsounds/tribeamequip.ogg'
 
@@ -370,10 +371,9 @@
 	desc = "The AER12, a successor to the AER9, is a cutting-edge state of the art laser rifle employed pre-war in specialty units, featuring green-beams and associated green-trim"
 	icon_state = "aer12"
 	item_state = "laser-rifle9"
-	ammo_type = list(/obj/item/ammo_casing/energy/laser/aer12)
+	ammo_type = list(/obj/item/ammo_casing/energy/laser/aer12/hitscan)
 	cell_type = /obj/item/stock_parts/cell/ammo/mfc
-	fire_delay = 3.5
-	can_scope = TRUE
+	fire_delay = 1.5
 	scope_state = "AEP7_scope"
 	scope_x_offset = 12
 	scope_y_offset = 20
@@ -386,10 +386,9 @@
 	desc = "The AER14, a successor to the AER9 and AER12, was a prototype in development before the Great War. It features an orange trim and higher firepower at the cost of slower firing rate."
 	icon_state = "aer14"
 	item_state = "laser-rifle9"
-	ammo_type = list(/obj/item/ammo_casing/energy/laser/aer14)
+	ammo_type = list(/obj/item/ammo_casing/energy/laser/aer14/hitscan)
 	cell_type = /obj/item/stock_parts/cell/ammo/mfc
-	fire_delay = 3.5
-	can_scope = TRUE
+	fire_delay = 1.5
 	scope_state = "AEP7_scope"
 	scope_x_offset = 12
 	scope_y_offset = 20
@@ -404,7 +403,7 @@
 	item_state = "laer"
 	fire_delay = 3
 	burst_size = 1
-	ammo_type = list(/obj/item/ammo_casing/energy/laser/laer)
+	ammo_type = list(/obj/item/ammo_casing/energy/laser/laer/hitscan)
 	cell_type = /obj/item/stock_parts/cell/ammo/mfc
 	equipsound = 'sound/f13weapons/equipsounds/laerequip.ogg'
 
@@ -417,7 +416,7 @@
 	item_state = "rcw"
 	fire_delay = 3
 	burst_size = 2
-	ammo_type = list(/obj/item/ammo_casing/energy/laser/rcw)
+	ammo_type = list(/obj/item/ammo_casing/energy/laser/rcw/hitscan)
 	cell_type = /obj/item/stock_parts/cell/ammo/ecp
 	equipsound = 'sound/f13weapons/equipsounds/RCWequip.ogg'
 

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -322,21 +322,16 @@
 //AER9 Laser rifle
 /obj/item/gun/energy/laser/aer9
 	name = "\improper AER9 laser rifle"
-	desc = "A sturdy and advanced military grade pre-war service laser rifle"
+	desc = "A sturdy pre-war laser rifle. Emits beams of concentrated light to kill targets. Fast firing, but not very powerful."
 	icon_state = "laser"
 	item_state = "laser-rifle9"
-	ammo_type = list(/obj/item/ammo_casing/energy/laser/lasgun)
+	ammo_type = list(/obj/item/ammo_casing/energy/laser/lasgun/hitscan)
 	cell_type = /obj/item/stock_parts/cell/ammo/mfc
 	fire_delay = 1
 	scope_state = "AEP7_scope"
 	scope_x_offset = 12
 	scope_y_offset = 20
 	equipsound = 'sound/f13weapons/equipsounds/aer9equip.ogg'
-
-/obj/item/gun/energy/laser/aer9/hitscan
-	desc = "A surprisingly well maintained pre-war laser rifle."
-	fire_delay = 1
-	ammo_type = list(/obj/item/ammo_casing/energy/laser/lasgun/hitscan)
 
 //Ultracite Laser rifle
 /obj/item/gun/energy/laser/ultra_rifle
@@ -356,11 +351,11 @@
 //Tribeam Laser rifle
 /obj/item/gun/energy/laser/scatter
 	name = "tribeam laser rifle"
-	desc = "A modified AER9 equipped with a refraction kit that spreads its bolts. It is usually only given to high-ranking soldiers within the Brotherhood, due to its level of technology, as well as its reputation of friendly fire."
+	desc = "A modified AER9 equipped with a refraction kit that divides the laser shot into three separate beams. While powerful, it has a reputation for friendly fire."
 	icon_state = "tribeam"
 	item_state = "laser-rifle9"
 	fire_delay = 3
-	ammo_type = list(/obj/item/ammo_casing/energy/laser/scatter/tribeam)
+	ammo_type = list(/obj/item/ammo_casing/energy/laser/scatter/tribeam/hitscan)
 	cell_type = /obj/item/stock_parts/cell/ammo/mfc
 	equipsound = 'sound/f13weapons/equipsounds/tribeamequip.ogg'
 
@@ -368,7 +363,7 @@
 //AER12 Laser rifle
 /obj/item/gun/energy/laser/aer12
 	name = "\improper AER12 laser rifle"
-	desc = "The AER12, a successor to the AER9, is a cutting-edge state of the art laser rifle employed pre-war in specialty units, featuring green-beams and associated green-trim"
+	desc = "A cutting-edge, pre-war laser rifle. Its focusing crystal array is housed in gold alloy, making it difficult to maintain."
 	icon_state = "aer12"
 	item_state = "laser-rifle9"
 	ammo_type = list(/obj/item/ammo_casing/energy/laser/aer12/hitscan)
@@ -383,7 +378,7 @@
 //AER14 Laser rifle
 /obj/item/gun/energy/laser/aer14
 	name = "\improper AER14 laser rifle"
-	desc = "The AER14, a successor to the AER9 and AER12, was a prototype in development before the Great War. It features an orange trim and higher firepower at the cost of slower firing rate."
+	desc = "A bleeding-edge, pre-war laser rifle. Extremely powerful, but eats MFCs like nothing else."
 	icon_state = "aer14"
 	item_state = "laser-rifle9"
 	ammo_type = list(/obj/item/ammo_casing/energy/laser/aer14/hitscan)
@@ -484,7 +479,7 @@
 	item_state = "plasma"
 	icon_state = "plasma"
 	fire_delay = 4.5
-	desc = "A top of line miniaturized plasma caster built by REPCONN in the wake of the Z43-521P failure. It is supperior to all previous rifles to enter service in the USCC."
+	desc = "A miniaturized plasma caster that fires bolts of magnetically accelerated toroidal plasma towards an unlucky target."
 	ammo_type = list(/obj/item/ammo_casing/energy/plasma)
 	cell_type = /obj/item/stock_parts/cell/ammo/mfc
 	equipsound = 'sound/f13weapons/equipsounds/plasequip.ogg'
@@ -495,7 +490,7 @@
 	name ="plasma carbine"
 	item_state = "plasma"
 	icon_state = "plasmacarbine"
-	desc = ""
+	desc = "A burst-fire energy weapon that fires a steady stream of toroidal plasma towards an unlucky target."
 	ammo_type = list(/obj/item/ammo_casing/energy/plasmacarbine)
 	cell_type = /obj/item/stock_parts/cell/ammo/mfc
 	burst_size = 2

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -355,7 +355,7 @@
 	icon_state = "tribeam"
 	item_state = "laser-rifle9"
 	fire_delay = 3
-	ammo_type = list(/obj/item/ammo_casing/energy/laser/scatter/tribeam/hitscan)
+	ammo_type = list(/obj/item/projectile/beam/laser/tribeam/hitscan)
 	cell_type = /obj/item/stock_parts/cell/ammo/mfc
 	equipsound = 'sound/f13weapons/equipsounds/tribeamequip.ogg'
 

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -492,7 +492,7 @@
 	damage = 35
 	armour_penetration = 0.25
 	wound_bonus = 20
-	tracer_type = /obj/effect/projectile/tracer/omnilaser
+	tracer_type = /obj/effect/projectile/tracer/pulse
 	muzzle_type = /obj/effect/projectile/muzzle/pulse
 	impact_type = /obj/effect/projectile/impact/pulse
 	hitscan = TRUE

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -312,13 +312,22 @@
 	damage = 35
 	armour_penetration = 0.25
 
-/obj/item/projectile/beam/laser/ultra_pistol
+/obj/item/projectile/beam/laser/pistol/hitscan //hitscan AEP7
+	name = "laser beam"
+	damage = 25
+	armour_penetration = 0.09
+	hitscan = TRUE
+	tracer_type = /obj/effect/projectile/tracer/laser
+	muzzle_type = /obj/effect/projectile/muzzle/laser
+	impact_type = /obj/effect/projectile/impact/laser
+
+/obj/item/projectile/beam/laser/ultra_pistol //unused
 	name = "laser beam"
 	damage = 40
 	armour_penetration = 0.35
 	irradiate = 200
 
-/obj/item/projectile/beam/laser/ultra_rifle
+/obj/item/projectile/beam/laser/ultra_rifle //unused
 	name = "laser beam"
 	damage = 45
 	armour_penetration = 0.42
@@ -332,20 +341,57 @@
 /obj/item/projectile/beam/laser/pistol/wattz //Wattz pistol
 	damage = 31
 
+/obj/item/projectile/beam/laser/pistol/wattz/hitscan //hitscan wattz
+	name = "weak laser beam"
+	damage = 15
+	armour_penetration = 0
+	hitscan = TRUE
+	tracer_type = /obj/effect/projectile/tracer/laser
+	muzzle_type = /obj/effect/projectile/muzzle/laser
+	impact_type = /obj/effect/projectile/impact/laser
+
 /obj/item/projectile/beam/laser/pistol/wattz/magneto //upgraded Wattz
 	name = "penetrating laser beam"
 	damage = 33
 	armour_penetration = 0.20
+
+/obj/item/projectile/beam/laser/pistol/wattz/magneto/hitscan
+	name = "penetrating laser beam"
+	damage = 15
+	hitscan = TRUE
+	armour_penetration = 0.2
+	tracer_type = /obj/effect/projectile/tracer/laser
+	muzzle_type = /obj/effect/projectile/muzzle/laser
+	impact_type = /obj/effect/projectile/impact/laser
 
 /obj/item/projectile/beam/laser/solar //Solar Scorcher
 	name = "solar scorcher beam"
 	damage = 28
 	armour_penetration = 0.42
 
+/obj/item/projectile/beam/laser/solar/hitscan
+	name = "solar scorcher beam"
+	damage = 27
+	armour_penetration = 0.15
+	hitscan = TRUE
+	tracer_type = /obj/effect/projectile/tracer/laser
+	muzzle_type = /obj/effect/projectile/muzzle/laser
+	impact_type = /obj/effect/projectile/impact/laser
+
 /obj/item/projectile/beam/laser/tribeam //Tribeam laser, fires 3 shots, will melt you
 	name = "tribeam laser"
 	damage = 21
 	armour_penetration = 0.25
+
+/obj/item/projectile/beam/laser/tribeam/hitscan
+	name = "tribeam laser"
+	damage = 15 //if all bullets connect, this will do 45.
+	armour_penetration = 0
+	hitscan = TRUE
+	bare_wound_bonus = -30 //tribeam is bad at wounding, as basically its only real downside
+	tracer_type = /obj/effect/projectile/tracer/laser
+	muzzle_type = /obj/effect/projectile/muzzle/laser
+	impact_type = /obj/effect/projectile/impact/laser
 
 /obj/item/projectile/f13plasma //Plasma rifle
 	name = "plasma bolt"
@@ -399,6 +445,17 @@
 	impact_effect_type = /obj/effect/temp_visual/impact_effect/green_laser
 	light_color = LIGHT_COLOR_GREEN
 
+/obj/item/projectile/beam/laser/rcw/hitscan //RCW
+	name = "rapidfire beam"
+	icon_state = "emitter"
+	damage = 15 //ALWAYS does 30, this is a burstfire hitscan weapon that fires in bursts of 2.
+	armour_penetration = 0.1
+	hitscan = TRUE
+	muzzle_type = /obj/effect/projectile/muzzle/laser/emitter
+	tracer_type = /obj/effect/projectile/tracer/laser/emitter
+	impact_type = /obj/effect/projectile/impact/laser/emitter
+	impact_effect_type = /obj/effect/temp_visual/impact_effect/green_laser
+
 /obj/item/projectile/f13plasma/pistol/alien
 	name = "alien projectile"
 	icon_state = "ion"
@@ -416,6 +473,13 @@
 	impact_effect_type = /obj/effect/temp_visual/impact_effect/blue_laser
 	light_color = LIGHT_COLOR_BLUE
 
+/obj/item/projectile/beam/laser/laer/hitscan
+	hitscan = TRUE
+
+/obj/item/projectile/beam/laser/laer/hitscan/Initialize()
+	. = ..()
+	transform *= 2
+
 /obj/item/projectile/beam/laser/aer14 //AER14
 	name = "laser beam"
 	damage = 38
@@ -423,6 +487,24 @@
 	icon_state = "omnilaser"
 	impact_effect_type = /obj/effect/temp_visual/impact_effect/blue_laser
 	light_color = LIGHT_COLOR_BLUE
+
+/obj/item/projectile/beam/laser/aer14/hitscan
+	damage = 35
+	armour_penetration = 0.25
+	wound_bonus = 20
+	tracer_type = /obj/effect/projectile/tracer/omnilaser
+	muzzle_type = /obj/effect/projectile/muzzle/pulse
+	impact_type = /obj/effect/projectile/impact/pulse
+	hitscan = TRUE
+	hitscan_light_intensity = 3
+	hitscan_light_range = 0.75
+	hitscan_light_color_override = LIGHT_COLOR_BLUE
+	muzzle_flash_intensity = 6
+	muzzle_flash_range = 2
+	muzzle_flash_color_override = LIGHT_COLOR_BLUE
+	impact_light_intensity = 7
+	impact_light_range = 2.5
+	impact_light_color_override = LIGHT_COLOR_BLUE
 
 /obj/item/projectile/beam/laser/aer12 //AER12
 	name = "laser beam"
@@ -432,10 +514,37 @@
 	impact_effect_type = /obj/effect/temp_visual/impact_effect/green_laser
 	light_color = LIGHT_COLOR_GREEN
 
+/obj/item/projectile/beam/laser/aer12/hitscan
+	name = "laser beam"
+	damage = 30
+	armour_penetration = 0.2
+	hitscan = TRUE
+	tracer_type = /obj/effect/projectile/tracer/xray
+	muzzle_type = /obj/effect/projectile/muzzle/xray
+	impact_type = /obj/effect/projectile/impact/xray
+	hitscan_light_intensity = 3
+	hitscan_light_range = 0.75
+	hitscan_light_color_override = COLOR_LIME
+	muzzle_flash_intensity = 6
+	muzzle_flash_range = 2
+	muzzle_flash_color_override = COLOR_LIME
+	impact_light_intensity = 7
+	impact_light_range = 2.5
+	impact_light_color_override = COLOR_LIME
+
 /obj/item/projectile/beam/laser/wattz2k
 	name = "laser bolt"
 	damage = 35
 	armour_penetration = 0.5
+
+/obj/item/projectile/beam/laser/wattz2k/hitscan
+	name = "sniper laser bolt"
+	damage = 20
+	armour_penetration = 0.3
+	tracer_type = /obj/effect/projectile/tracer/heavy_laser
+	muzzle_type = /obj/effect/projectile/muzzle/heavy_laser
+	impact_type = /obj/effect/projectile/impact/heavy_laser
+	hitscan = TRUE
 
 /obj/item/projectile/beam/laser/musket //musket
 	name = "laser bolt"


### PR DESCRIPTION
this pr is a test

the gatling laser isn't hitscan because i didn't even want to fuck with that

all lasers are relatively low damage and low AP to no AP in exchange for a much higher fire rate, and proportionally more shots per cell as well as being hitscan. they're not scopeable anymore since the 'scoped hitscan' would be a terrible idea (except for the wattz, which is still scoped)

this will be tuned as needed

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
:cl:
add: HITSCAN
/:cl:
