### PR TITLE
maybe dont waste cpu on dead mobs

### DIFF
--- a/code/datums/components/glow_heal.dm
+++ b/code/datums/components/glow_heal.dm
@@ -52,6 +52,10 @@
 			continue
 		if(faction_only && !(faction_only in livingMob.faction))
 			continue //if you don't have the faction listed in the intial, then you aren't getting targeted 
+		if(livingMob.stat == DEAD) 
+			if(revive_allowed)
+				livingMob.revive(full_heal = TRUE)
+			return //dont waste cpu on dead mobs that cant be revived
 		if(healing_types && BRUTELOSS)
 			livingMob.adjustBruteLoss(-livingMob.maxHealth*0.1)
 		if(healing_types && FIRELOSS)	
@@ -60,7 +64,5 @@
 			livingMob.adjustToxLoss(-livingMob.maxHealth*0.1)
 		if(healing_types && OXYLOSS)	
 			livingMob.adjustOxyLoss(-livingMob.maxHealth*0.1)
-		if(livingMob.stat == DEAD && revive_allowed)
-			livingMob.revive(full_heal = TRUE)
 		var/obj/effect/temp_visual/heal/H = new /obj/effect/temp_visual/heal(get_turf(livingMob)) //shameless copy from blobbernaut
 		H.color = glow_color

--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -654,6 +654,8 @@
 
 	if(isobj(target))
 		if(actually_paints)
+			if(istype(target, /obj/item/canvas))
+				return
 			var/list/hsl = rgb2hsl(hex2num(copytext(paint_color,2,4)),hex2num(copytext(paint_color,4,6)),hex2num(copytext(paint_color,6,8)))
 			var/static/whitelisted = typecacheof(list(/obj/structure/window,
 										/obj/effect/decal/cleanable/crayon,


### PR DESCRIPTION
stops glow_heal from healing dead mobs that arent revivable

also stops spraycans from coloring canvases when you're trying to paint them